### PR TITLE
Implement merging sibling/cousin scopes based on their ID

### DIFF
--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -246,7 +246,7 @@ impl ProfilerUi {
                     .add_text([painter.canvas_min.x(), cursor_y], ERROR_COLOR, &text);
             }
 
-            cursor_y -= painter.font_size; // Extra spacing betwen threads
+            cursor_y -= painter.font_size; // Extra spacing between threads
         }
     }
 
@@ -358,16 +358,7 @@ fn paint_timeline(
             };
 
             if text_alpha > 0.0 {
-                let grid_ms = to_ms(grid_ns);
-                let text = if grid_ns % 1_000_000 == 0 {
-                    format!("{:.0} ms", grid_ms)
-                } else if grid_ns % 100_000 == 0 {
-                    format!("{:.1} ms", grid_ms)
-                } else if grid_ns % 10_000 == 0 {
-                    format!("{:.2} ms", grid_ms)
-                } else {
-                    format!("{:.3} ms", grid_ms)
-                };
+                let text = grid_text(grid_ns);
                 let text_x = line_x + 4.0;
                 let text_color = [1.0, 1.0, 1.0, (text_alpha * 2.0).min(1.0)];
 
@@ -386,6 +377,19 @@ fn paint_timeline(
         }
 
         grid_ns += grid_spacing_ns;
+    }
+}
+
+fn grid_text(grid_ns: NanoSecond) -> String {
+    let grid_ms = to_ms(grid_ns);
+    if grid_ns % 1_000_000 == 0 {
+        format!("{:.0} ms", grid_ms)
+    } else if grid_ns % 100_000 == 0 {
+        format!("{:.1} ms", grid_ms)
+    } else if grid_ns % 10_000 == 0 {
+        format!("{:.2} ms", grid_ms)
+    } else {
+        format!("{:.3} ms", grid_ms)
     }
 }
 
@@ -527,8 +531,12 @@ fn paint_scope(
             let ui = painter.ui;
             ui.tooltip(|| {
                 ui.text(&format!("id:       {}", scope.record.id));
+                if !scope.record.location.is_empty() {
                 ui.text(&format!("location: {}", scope.record.location));
+                }
+                if !scope.record.data.is_empty() {
                 ui.text(&format!("data:     {}", scope.record.data));
+                }
                 ui.text(&format!(
                     "duration: {:6.3} ms",
                     to_ms(scope.record.duration_ns)

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -396,7 +396,7 @@ fn paint_record(
     top_y: f32,
 ) -> PaintResult {
     let start_x = painter.pixel_from_ns(options, record.start_ns);
-    let stop_x = painter.pixel_from_ns(options, record.stop_ns);
+    let stop_x = painter.pixel_from_ns(options, record.stop_ns());
     let width = stop_x - start_x;
     if painter.canvas_max.x() < start_x
         || stop_x < painter.canvas_min.x()
@@ -418,7 +418,7 @@ fn paint_record(
         [1.0, 0.5, 0.5, 1.0]
     } else {
         // options.rect_color
-        color_from_duration(record.duration_ns())
+        color_from_duration(record.duration_ns)
     };
     let text_color = [0.1, 0.1, 0.1, 1.0];
 
@@ -437,7 +437,7 @@ fn paint_record(
         painter
             .draw_list
             .with_clip_rect_intersect(rect_min.into(), rect_max.into(), || {
-                let duration_ms = to_ms(record.duration_ns());
+                let duration_ms = to_ms(record.duration_ns);
                 let text = if record.data.is_empty() {
                     format!("{} {:6.3} ms", record.id, duration_ms)
                 } else {
@@ -531,7 +531,7 @@ fn paint_scope(
                 ui.text(&format!("data:     {}", scope.record.data));
                 ui.text(&format!(
                     "duration: {:6.3} ms",
-                    to_ms(scope.record.duration_ns())
+                    to_ms(scope.record.duration_ns)
                 ));
                 ui.text(&format!("children: {}", num_children));
             });

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -220,7 +220,8 @@ impl ProfilerUi {
             self.options.pixels_per_ns = painter.canvas_width() / ((max_ns - min_ns) as f32);
         }
 
-        paint_timeline(&painter, &self.options, min_ns, max_ns);
+        let options = &self.options;
+        paint_timeline(&painter, options, min_ns, max_ns);
 
         // We paint the threads bottom up
         let mut cursor_y = painter.canvas_max[1];
@@ -244,21 +245,14 @@ impl ProfilerUi {
 
             let mut paint_stream = || -> Result<()> {
                 let top_scopes = Reader::from_start(stream).read_top_scopes()?;
-                if self.options.merge_scopes {
+                if options.merge_scopes {
                     let merges = puffin::merge_top_scopes(&top_scopes);
                     for merge in merges {
-                        paint_merge_scope(
-                            &painter,
-                            &self.options,
-                            stream,
-                            &merge,
-                            0,
-                            &mut cursor_y,
-                        )?;
+                        paint_merge_scope(&painter, options, stream, &merge, 0, &mut cursor_y)?;
                     }
                 } else {
                     for scope in top_scopes {
-                        paint_scope(&painter, &self.options, stream, &scope, 0, &mut cursor_y)?;
+                        paint_scope(&painter, options, stream, &scope, 0, &mut cursor_y)?;
                     }
                 }
                 Ok(())

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -358,7 +358,7 @@ fn paint_timeline(
             };
 
             if text_alpha > 0.0 {
-                let grid_ms = 1e-6 * (grid_ns as f64);
+                let grid_ms = to_ms(grid_ns);
                 let text = if grid_ns % 1_000_000 == 0 {
                     format!("{:.0} ms", grid_ms)
                 } else if grid_ns % 100_000 == 0 {
@@ -418,7 +418,7 @@ fn paint_record(
         [1.0, 0.5, 0.5, 1.0]
     } else {
         // options.rect_color
-        color_from_duration_ms(record.duration_ns() as f32 * 1e-6)
+        color_from_duration(record.duration_ns())
     };
     let text_color = [0.1, 0.1, 0.1, 1.0];
 
@@ -437,7 +437,7 @@ fn paint_record(
         painter
             .draw_list
             .with_clip_rect_intersect(rect_min.into(), rect_max.into(), || {
-                let duration_ms = 1e-6 * (record.duration_ns() as f32);
+                let duration_ms = to_ms(record.duration_ns());
                 let text = if record.data.is_empty() {
                     format!("{} {:6.3} ms", record.id, duration_ms)
                 } else {
@@ -461,7 +461,8 @@ fn paint_record(
     }
 }
 
-fn color_from_duration_ms(ms: f32) -> [f32; 4] {
+fn color_from_duration(ns: NanoSecond) -> [f32; 4] {
+    let ms = to_ms(ns) as f32;
     // Brighter = more time.
     // So we start with dark colors (blue) and later bright colors (green).
     let b = remap_clamp(ms, 0.0..=5.0, 1.0..=0.0);
@@ -469,6 +470,10 @@ fn color_from_duration_ms(ms: f32) -> [f32; 4] {
     let g = remap_clamp(ms, 10.0..=20.0, 0.0..=0.8);
     let a = 0.8;
     [r, g, b, a]
+}
+
+fn to_ms(ns: NanoSecond) -> f64 {
+    ns as f64 * 1e-6
 }
 
 use std::ops::{Add, Mul, RangeInclusive};
@@ -526,7 +531,7 @@ fn paint_scope(
                 ui.text(&format!("data:     {}", scope.record.data));
                 ui.text(&format!(
                     "duration: {:6.3} ms",
-                    scope.record.duration_ns() as f32 * 1e-6
+                    to_ms(scope.record.duration_ns())
                 ));
                 ui.text(&format!("children: {}", num_children));
             });

--- a/puffin/src/data.rs
+++ b/puffin/src/data.rs
@@ -6,7 +6,7 @@
 //!
 //!    '('          byte       Sentinel
 //!    time_ns      i64        Time stamp of when scope started
-//!    id           str        Scope name. Human readable, e.g. a function name. Never the empty stirng.
+//!    id           str        Scope name. Human readable, e.g. a function name. Never the empty string.
 //!    location     str        File name or similar. Could be the empty string.
 //!    data         str        Resource that is being processed, e.g. name of image being loaded. Could be the empty string.
 //!    scope_size   u64        Number of bytes of child scope

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -91,7 +91,7 @@ impl From<Vec<u8>> for Stream {
 #[derive(Debug, PartialEq)]
 pub struct Record<'s> {
     pub start_ns: NanoSecond,
-    pub stop_ns: NanoSecond,
+    pub duration_ns: NanoSecond,
 
     /// e.g. function name. Mandatory. Used to identify records.
     /// Does not need to be globally unique, just unique in the parent scope.
@@ -108,8 +108,8 @@ pub struct Record<'s> {
 }
 
 impl<'s> Record<'s> {
-    pub fn duration_ns(&self) -> NanoSecond {
-        self.stop_ns - self.start_ns
+    pub fn stop_ns(&self) -> NanoSecond {
+        self.start_ns + self.duration_ns
     }
 }
 
@@ -149,7 +149,7 @@ impl FullProfileData {
             let top_scopes = Reader::from_start(stream).read_top_scopes()?;
             if !top_scopes.is_empty() {
                 min_ns = min_ns.min(top_scopes.first().unwrap().record.start_ns);
-                max_ns = max_ns.max(top_scopes.last().unwrap().record.stop_ns);
+                max_ns = max_ns.max(top_scopes.last().unwrap().record.stop_ns());
             }
         }
 

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -88,7 +88,7 @@ impl From<Vec<u8>> for Stream {
 }
 
 /// Used when parsing a Stream.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Record<'s> {
     pub start_ns: NanoSecond,
     pub duration_ns: NanoSecond,
@@ -114,7 +114,7 @@ impl<'s> Record<'s> {
 }
 
 /// Used when parsing a Stream.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Scope<'s> {
     pub record: Record<'s>,
     /// Stream offset for first child.
@@ -220,6 +220,7 @@ impl ThreadProfiler {
     }
 
     /// Returns position where to write scope size once the scope is closed.
+    #[must_use]
     pub fn begin_scope(&mut self, id: &str, location: &str, data: &str) -> usize {
         let now_ns = (self.now_ns)();
         self.start_time_ns = Some(self.start_time_ns.unwrap_or(now_ns));

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -34,8 +34,10 @@
 )]
 
 mod data;
+mod merge;
 
 pub use data::*;
+pub use merge::*;
 
 use parking_lot::Mutex;
 use std::collections::BTreeMap;

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -1,0 +1,189 @@
+use crate::{NanoSecond, Reader, Record, Result, Scope, Stream};
+use std::collections::HashMap;
+
+/// An record of several sibling (or cousin) scopes.
+///
+/// For instance, if one scope has a hundred children of the same ID
+/// the UI may want to merge them into one child before display.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MergeScope<'s> {
+    /// The aggregated information.
+    ///
+    /// `record.duration_ns` is the sum `self.pieces`.
+    pub record: Record<'s>,
+
+    /// These are the raw scopes that got merged into `self.record`.
+    /// All these scopes have the same `id` is `self.record`.
+    pub pieces: Vec<MergePiece<'s>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MergePiece<'s> {
+    /// The start of the scope relative to its *parent* `Scope` (not to any `MergeScope`).
+    pub relative_start_ns: NanoSecond,
+    /// The raw scope, just like it is found in the input stream
+    pub scope: Scope<'s>,
+}
+
+pub fn merge_top_scopes<'s>(scopes: &[Scope<'s>]) -> Vec<MergeScope<'s>> {
+    merge_pieces(scopes.iter().map(|scope| MergePiece {
+        relative_start_ns: scope.record.start_ns,
+        scope: *scope,
+    }))
+}
+
+pub fn merge_children_of_pieces<'s>(
+    stream: &'s Stream,
+    parent: &MergeScope<'s>,
+) -> Result<Vec<MergeScope<'s>>> {
+    // collect all children of all the pieces scopes:
+    let mut child_pieces = Vec::new();
+    for piece in &parent.pieces {
+        for child in
+            Reader::with_offset(stream, piece.scope.child_begin_position)?.read_top_scopes()?
+        {
+            child_pieces.push(MergePiece {
+                relative_start_ns: child.record.start_ns - piece.scope.record.start_ns,
+                scope: child,
+            });
+        }
+    }
+
+    let mut merges = merge_pieces(child_pieces);
+
+    // Move from relative to absolute time:
+    for merge in &mut merges {
+        merge.record.start_ns += parent.record.start_ns;
+    }
+
+    Ok(merges)
+}
+
+/// Group scopes based on their `record.id` (deinterleaving).
+/// The returned merge scopes uses relative times.
+fn merge_pieces<'s>(pieces: impl IntoIterator<Item = MergePiece<'s>>) -> Vec<MergeScope<'s>> {
+    let mut merges: Vec<MergeScope<'s>> = Default::default();
+    let mut index_from_id: HashMap<&'s str, usize> = Default::default();
+
+    for piece in pieces {
+        let record = piece.scope.record;
+
+        match index_from_id.get(record.id).cloned() {
+            None => {
+                index_from_id.insert(record.id, merges.len());
+                merges.push(MergeScope {
+                    record: Record {
+                        start_ns: piece.relative_start_ns,
+                        ..record
+                    },
+                    pieces: vec![piece],
+                });
+            }
+            Some(index) => {
+                let merge = &mut merges[index];
+
+                // Merged scope should start at the earliest piece:
+                merge.record.start_ns = merge.record.start_ns.min(piece.relative_start_ns);
+
+                // Accumulate time:
+                merge.record.duration_ns += record.duration_ns;
+
+                if merge.record.data != record.data {
+                    merge.record.data = ""; // different in different pieces
+                }
+                if merge.record.location != record.location {
+                    merge.record.location = ""; // different in different pieces
+                }
+
+                merge.pieces.push(piece);
+            }
+        }
+    }
+
+    if !merges.is_empty() {
+        // Earliest first:
+        merges.sort_by_key(|merged_scope| merged_scope.record.start_ns);
+
+        // Make sure children do not overlap:
+        let mut ns = 0;
+        for merge in &mut merges {
+            merge.record.start_ns = merge.record.start_ns.max(ns);
+            ns = merge.record.stop_ns();
+        }
+    }
+
+    merges
+}
+
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_merge() {
+    use crate::*;
+
+    let stream = {
+        let mut stream = Stream::default();
+
+        for i in 0..2 {
+            let ns = 1000 * i;
+            let a = stream.begin_scope(ns + 100, "a", "", "");
+            stream.end_scope(a, ns + 200);
+
+            let b = stream.begin_scope(ns + 200, "b", "", "");
+
+            let ba = stream.begin_scope(ns + 400, "ba", "", "");
+            stream.end_scope(ba, ns + 600);
+
+            let bb = stream.begin_scope(ns + 600, "bb", "", "");
+            let bba = stream.begin_scope(ns + 600, "bba", "", "");
+            stream.end_scope(bba, ns + 700);
+            stream.end_scope(bb, ns + 800);
+            stream.end_scope(b, ns + 900);
+        }
+
+        stream
+    };
+
+    let top_scopes = Reader::from_start(&stream).read_top_scopes().unwrap();
+    assert_eq!(top_scopes.len(), 4);
+
+    let merged = merge_top_scopes(&top_scopes);
+    assert_eq!(merged.len(), 2);
+
+    assert_eq!(
+        merged[0].record,
+        Record {
+            start_ns: 100,
+            duration_ns: 2 * 100,
+            id: "a",
+            location: "",
+            data: ""
+        }
+    );
+    assert_eq!(
+        merged[1].record,
+        Record {
+            start_ns: 300, // moved forward to make place for "a" (as are all children)
+            duration_ns: 2 * 700,
+            id: "b",
+            location: "",
+            data: ""
+        }
+    );
+    assert_eq!(merged[1].pieces.len(), 2);
+
+    let b_merged = merge_children_of_pieces(&stream, &merged[1]).unwrap();
+    assert_eq!(b_merged.len(), 2);
+    assert_eq!(b_merged[0].record.id, "ba");
+    assert_eq!(b_merged[0].record.start_ns, 500);
+    assert_eq!(b_merged[0].record.duration_ns, 2 * 200);
+    assert_eq!(b_merged[1].record.id, "bb");
+    assert_eq!(b_merged[1].record.start_ns, 900);
+    assert_eq!(b_merged[1].record.duration_ns, 2 * 200);
+
+    let bb_merged = merge_children_of_pieces(&stream, &b_merged[1]).unwrap();
+    assert_eq!(bb_merged.len(), 1);
+    assert_eq!(bb_merged[0].record.id, "bba");
+    assert_eq!(bb_merged[0].record.start_ns, 900);
+    assert_eq!(bb_merged[0].record.duration_ns, 2 * 100);
+}


### PR DESCRIPTION
Closes https://github.com/EmbarkStudios/puffin/issues/3

This improves the UI view a lot when you have a bunch of child scopes being repeated:

<img width="943" alt="before_merge" src="https://user-images.githubusercontent.com/1148717/91174648-ddb5dc00-e6df-11ea-8b7c-dd1706caafa3.png">

<img width="902" alt="with_merge" src="https://user-images.githubusercontent.com/1148717/91174664-e1e1f980-e6df-11ea-818c-7d92e84a9194.png">
