### PR TITLE
Bump imgui to 0.6.0

### DIFF
--- a/puffin-imgui/Cargo.toml
+++ b/puffin-imgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin-imgui"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Embark <opensource@embark-studios.com>"]
 description = "ImGui GUI bindings for the Puffin profiler"
 license = "MIT OR Apache-2.0"
@@ -16,6 +16,6 @@ include = [ "**/*.rs", "Cargo.toml"]
 doctest = false
 
 [dependencies]
-imgui = { version = "0.4" }
+imgui = { version = "0.6" }
 puffin = { version = "0.3.1", path = "../puffin" }
 serde = { version = "1", features = ["derive"] }

--- a/puffin-imgui/Cargo.toml
+++ b/puffin-imgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin-imgui"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 description = "ImGui GUI bindings for the Puffin profiler"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Probably could have pushed this to main directly but wanted to double-check if `0.4.1` is ok. :)
