### PR TITLE
Remove `parking_lot` to fix wasm32-unknown-unknown

### DIFF
--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -18,7 +18,6 @@ doctest = false
 [dependencies]
 byteorder = { version = "1" }
 once_cell = "1"
-parking_lot = "0.11"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -60,9 +60,9 @@ mod merge;
 pub use data::*;
 pub use merge::*;
 
-use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 static MACROS_ON: AtomicBool = AtomicBool::new(false);
 
@@ -293,10 +293,10 @@ pub struct GlobalProfiler {
 
 impl GlobalProfiler {
     /// Access to the global profiler singleton.
-    pub fn lock() -> parking_lot::MutexGuard<'static, Self> {
+    pub fn lock() -> std::sync::MutexGuard<'static, Self> {
         use once_cell::sync::Lazy;
         static GLOBAL_PROFILER: Lazy<Mutex<GlobalProfiler>> = Lazy::new(Default::default);
-        GLOBAL_PROFILER.lock()
+        GLOBAL_PROFILER.lock().unwrap() // panic on mutex poisioning
     }
 
     /// You need to call once every frame.


### PR DESCRIPTION
Works around https://github.com/Amanieu/parking_lot/issues/269 where later versions of `parking_lot` were pulling in an undefined `env::now` symbol failing to be used in `wasm32-unknown-unknown` target (when not targetting web environments).

Replaced for now with just `std::sync::Mutex`, though we could optionally use `parking_lot` on non-wasm32 and use just "unsafe" single-threaded access for `wasm32-unknown-unknown`.

Do want that core issue in parking_lot to be resolved, or at least clarified if non-web wasm32 is a target or not. But at least this solves our problems for now in our own crate.
