### PR TITLE
Set text color to pure black to increase legibility

### DIFF
--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -497,7 +497,7 @@ fn paint_record(
         // options.rect_color
         color_from_duration(record.duration_ns)
     };
-    let text_color = [0.1, 0.1, 0.1, 1.0];
+    let text_color = [0.0, 0.0, 0.0, 1.0];
 
     painter
         .draw_list


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This sets the font color to pure black to improve legibility. I think my gamma settings are correct because the other colors being rendered by imgui look correct. However, I struggle to read the 10% gray against the vivid purple. This is especially pronounced with thinner fonts. (It was actually must worse when I was using a different font!)

### Before

**Font 1**
![image](https://user-images.githubusercontent.com/316070/111097268-70905980-84fe-11eb-808f-749c5b3a6345.png)

**Font 2**
![image](https://user-images.githubusercontent.com/316070/111096896-c284af80-84fd-11eb-88e2-1a61aba820b4.png)

### After

**Font 1**
![image](https://user-images.githubusercontent.com/316070/111097281-76863a80-84fe-11eb-8c3f-caadf58ab4c6.png)

**Font 2**
![image](https://user-images.githubusercontent.com/316070/111096820-a4b74a80-84fd-11eb-894a-2e5bf167ebbd.png)

