### PR TITLE
Keep and show history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to `puffin` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+* `GlobalProfiler` now store recent history and the slowest frames

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -6,5 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Select frames from recent history or from among the slowest ever
 * Nicer colors
 * Simpler interaction (drag to pan, scroll to zoom)

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -6,6 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Select frames from recent history or from among the slowest ever
-* Nicer colors
-* Simpler interaction (drag to pan, scroll to zoom)
+* Select frames from recent history or from among the slowest ever.
+* Nicer colors.
+* Simpler interaction (drag to pan, scroll to zoom, click to focus, double-click to reset).

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -225,33 +225,37 @@ impl ProfilerUi {
             ui.text_colored(ERROR_COLOR, im_str!("The puffin profiler is OFF!"));
         }
 
-        if self.paused_frames.is_none() {
-            // showing latest data
-            if ui.button(im_str!("Pause"), Default::default()) {
-                self.paused_frames = Some(self.frames());
-                if matches!(&self.selected, Selected::Latest) {
-                    if let Some(latest) = GlobalProfiler::lock().latest_frame() {
-                        self.selected = Selected::Specific(latest);
-                    }
-                }
-            }
-            ui.same_line(0.0);
-            if ui.button(im_str!("Clear slowest frames"), Default::default()) {
-                GlobalProfiler::lock().clear_slowest();
-                self.paused_frames = None;
-            }
-        } else {
-            if ui.button(im_str!("Resume"), Default::default()) {
-                self.paused_frames = None;
-            }
-        }
         let mut hovered_frame = None;
         if imgui::CollapsingHeader::new(im_str!("Frames"))
             .default_open(true)
             .build(ui)
         {
             ui.indent();
+
             hovered_frame = self.show_frames(ui);
+
+            if self.paused_frames.is_none() {
+                // showing latest data
+                if ui.button(im_str!("Pause"), Default::default()) {
+                    self.paused_frames = Some(self.frames());
+                    if matches!(&self.selected, Selected::Latest) {
+                        if let Some(latest) = GlobalProfiler::lock().latest_frame() {
+                            self.selected = Selected::Specific(latest);
+                        }
+                    }
+                }
+                ui.same_line(0.0);
+                if ui.button(im_str!("Clear slowest frames"), Default::default()) {
+                    GlobalProfiler::lock().clear_slowest();
+                    self.paused_frames = None;
+                }
+            } else {
+                if ui.button(im_str!("Resume"), Default::default()) {
+                    self.paused_frames = None;
+                }
+            }
+
+            ui.same_line(0.0);
 
             match &self.selected {
                 Selected::Latest => {
@@ -267,6 +271,7 @@ impl ProfilerUi {
                     }
                 }
             }
+
             ui.unindent();
         }
 

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -458,7 +458,7 @@ impl ProfilerUi {
                 } else if is_hovered {
                     HOVER_COLOR
                 } else {
-                    color_from_duration(duration)
+                    [0.6, 0.6, 0.4, 1.0]
                 };
 
                 // Transparent, full height:

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -241,28 +241,33 @@ impl ProfilerUi {
                 self.paused_frames = None;
             }
         } else {
-            ui.text("(paused)");
-            ui.same_line(0.0);
             if ui.button(im_str!("Resume"), Default::default()) {
                 self.paused_frames = None;
             }
         }
+        let mut hovered_frame = None;
+        if imgui::CollapsingHeader::new(im_str!("Frames"))
+            .default_open(true)
+            .build(ui)
+        {
+            ui.indent();
+            hovered_frame = self.show_frames(ui);
 
-        let mut hovered_frame = self.show_frames(ui);
-
-        match &self.selected {
-            Selected::Latest => {
-                ui.text("Latest frame selected");
-            }
-            Selected::Specific(_frame) => {
-                if ui.button(im_str!("Select latest frame"), Default::default()) {
-                    self.selected = Selected::Latest;
-                    self.paused_frames = None;
+            match &self.selected {
+                Selected::Latest => {
+                    ui.text("Latest frame selected");
                 }
-                if ui.is_item_hovered() {
-                    hovered_frame = GlobalProfiler::lock().latest_frame();
+                Selected::Specific(_frame) => {
+                    if ui.button(im_str!("Show latest frame"), Default::default()) {
+                        self.selected = Selected::Latest;
+                        self.paused_frames = None;
+                    }
+                    if ui.is_item_hovered() {
+                        hovered_frame = GlobalProfiler::lock().latest_frame();
+                    }
                 }
             }
+            ui.unindent();
         }
 
         let frame = match hovered_frame.or_else(|| self.selected_frame()) {

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -56,7 +56,7 @@ impl std::ops::Add<Vec2> for Vec2 {
 // ----------------------------------------------------------------------------
 
 const ERROR_COLOR: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
-const HOVER_COLOR: [f32; 4] = [0.85, 0.85, 0.85, 1.0];
+const HOVER_COLOR: [f32; 4] = [0.8, 0.8, 0.8, 1.0];
 
 /// The frames we can select between
 #[derive(Clone)]
@@ -457,11 +457,7 @@ impl ProfilerUi {
                 };
 
                 // Transparent, full height:
-                color[3] = if is_selected || is_hovered {
-                    0.75
-                } else {
-                    0.25
-                };
+                color[3] = if is_selected || is_hovered { 0.6 } else { 0.25 };
                 draw_list
                     .add_rect(rect_min.into(), rect_max.into(), color)
                     .filled(true)

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -695,7 +695,7 @@ fn color_from_duration(ns: NanoSecond) -> [f32; 4] {
     // So we start with dark colors (blue) and later bright colors (green).
     let b = remap_clamp(ms, 0.0..=5.0, 1.0..=0.3);
     let r = remap_clamp(ms, 0.0..=10.0, 0.5..=0.8);
-    let g = remap_clamp(ms, 10.0..=20.0, 0.1..=0.8);
+    let g = remap_clamp(ms, 10.0..=33.3, 0.1..=0.8);
     let a = 0.9;
     [r, g, b, a]
 }

--- a/puffin/src/data.rs
+++ b/puffin/src/data.rs
@@ -46,6 +46,7 @@ pub enum Error {
     InvalidStream,
     ScopeNeverEnded,
     InvalidOffset,
+    Empty,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -216,6 +217,19 @@ impl<'s> Reader<'s> {
         } else {
             Err(Error::PrematureEnd)
         }
+    }
+
+    /// Recursively count all profile scopes in a stream
+    pub fn count_all_scopes(stream: &Stream) -> Result<usize> {
+        Self::count_all_scopes_at_offset(stream, 0)
+    }
+
+    pub fn count_all_scopes_at_offset(stream: &Stream, offset: u64) -> Result<usize> {
+        let mut sum = 0;
+        for child_scope in Reader::with_offset(stream, offset)? {
+            sum += 1 + Self::count_all_scopes_at_offset(stream, child_scope?.child_begin_position)?;
+        }
+        Ok(sum)
     }
 }
 

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -374,7 +374,9 @@ impl GlobalProfiler {
         GLOBAL_PROFILER.lock().unwrap() // panic on mutex poisoning
     }
 
-    /// You need to call once every frame.
+    /// You need to call this once at the start of every frame.
+    ///
+    /// It is fine to call this from within a profile scope.
     pub fn new_frame(&mut self) {
         let current_frame_index = self.current_frame_index;
         self.current_frame_index += 1;
@@ -413,37 +415,45 @@ impl GlobalProfiler {
         self.current_frame.entry(info).or_default().append(stream);
     }
 
+    /// The latest fully captured frame of data.
     pub fn latest_frame(&self) -> Option<Arc<FrameData>> {
         self.recent_frames.back().cloned()
     }
 
-    /// oldest first
+    /// Oldest first
     pub fn recent_frames(&self) -> impl Iterator<Item = &Arc<FrameData>> {
         self.recent_frames.iter()
     }
 
     /// The slowest frames so far (or since last call to [`Self::clear_slowest`])
-    /// in chronological order
+    /// in chronological order.
     pub fn slowest_frames_chronological(&self) -> Vec<Arc<FrameData>> {
         let mut frames: Vec<_> = self.slowest_frames.iter().map(|f| f.0.clone()).collect();
         frames.sort_by_key(|frame| frame.frame_index);
         frames
     }
 
-    /// Clean history of the slowest frames
+    /// Clean history of the slowest frames.
     pub fn clear_slowest(&mut self) {
         self.slowest_frames.clear();
     }
 
+    /// How many frames of recent history to store.
     pub fn max_recent(&self) -> usize {
         self.max_recent
     }
+
+    /// How many frames of recent history to store.
     pub fn set_max_history(&mut self, max_recent: usize) {
         self.max_recent = max_recent
     }
+
+    /// How many slow "spike" frames to store.
     pub fn max_slow(&self) -> usize {
         self.max_slow
     }
+
+    /// How many slow "spike" frames to store.
     pub fn set_max_slow(&mut self, max_slow: usize) {
         self.max_slow = max_slow
     }

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -25,6 +25,7 @@ pub struct MergePiece<'s> {
     pub scope: Scope<'s>,
 }
 
+/// Merge sibling scopes with the same id.
 pub fn merge_top_scopes<'s>(scopes: &[Scope<'s>]) -> Vec<MergeScope<'s>> {
     merge_pieces(scopes.iter().map(|scope| MergePiece {
         relative_start_ns: scope.record.start_ns,
@@ -32,6 +33,7 @@ pub fn merge_top_scopes<'s>(scopes: &[Scope<'s>]) -> Vec<MergeScope<'s>> {
     }))
 }
 
+/// Merge sibling scopes with the same id.
 pub fn merge_children_of_pieces<'s>(
     stream: &'s Stream,
     parent: &MergeScope<'s>,


### PR DESCRIPTION
`GlobalProfiler` now keep tracks of a history of recent frames, and a separate history of the slowest frames.

These can be viewed in `puffin-imgui`.

Closes https://github.com/EmbarkStudios/puffin/issues/2 (mostly)

In addition, a lot of improvements to `puffin-imgui`, with easier navigation (click to zoom, double-click to reset view) and other minor tweaks.

These are breaking changes.