### PR TITLE
Fix eframe docsrs link

### DIFF
--- a/puffin_egui/README.md
+++ b/puffin_egui/README.md
@@ -26,6 +26,6 @@ puffin_egui::profiler_window(egui_ctx);
 
 <img src="../puffin_egui.gif">
 
-See the [`examples/`](examples/) folder for how to use it with [`eframe`](docs.rs/eframe) or [`macroquad`](https://github.com/not-fl3/macroquad).
+See the [`examples/`](examples/) folder for how to use it with [`eframe`](https://docs.rs/eframe) or [`macroquad`](https://github.com/not-fl3/macroquad).
 
 To try it out, run `cargo run --release --example macroquad`


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This adds an `https://` to a link in the puffin-egui README.

Without the `https://`, GitHub interprets the markdown link as a file-relative link rather than an HTTP URL.
