### PR TITLE
UI improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "imgui",
  "imgui-glium-renderer",
  "imgui-winit-support",
+ "natord",
  "puffin",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "ndk"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2214,7 @@ dependencies = [
  "egui",
  "egui-macroquad",
  "macroquad",
+ "natord",
  "once_cell",
  "puffin",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,8 +901,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "eframe"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3677cb27e360092b5078c5aaae1edf4b84d900b2e5ee61e93c71c4f2574e97a"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "egui",
  "egui_glium",
@@ -913,8 +912,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f9b394ccacc0cccb30f6de7371038a116931aa3186acd908b9ec61f405f15c"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "epaint",
  "ron",
@@ -947,8 +945,7 @@ dependencies = [
 [[package]]
 name = "egui_glium"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da94629a664a360708c91495dbae0a55c0e05acec5e05fcc6c99beabd6036036"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "copypasta",
  "directories-next",
@@ -963,8 +960,7 @@ dependencies = [
 [[package]]
 name = "egui_web"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8d91b33af1d26ba3f7b22819e7bfdcb596e2d3a382eacec2363960eacdf643"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "egui",
  "epi",
@@ -985,8 +981,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "emath"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80eea7508c08a7b4e2a041adcdca6f400d8606622c6bb980ecbbdc5f1aff9a4c"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "serde",
 ]
@@ -994,8 +989,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132e30d483d9fa252fe06aa112de777d068503c379fa51bc5834204ee3258fce"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "ab_glyph",
  "ahash 0.7.4",
@@ -1008,8 +1002,7 @@ dependencies = [
 [[package]]
 name = "epi"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b04a4a240553fa9254d0569cf3aa22d9dbe77a66025e1f04b0785744629c9ec"
+source = "git+https://github.com/emilk/egui?rev=faf104220be18cda878e9864bab3760caa4901d8#faf104220be18cda878e9864bab3760caa4901d8"
 dependencies = [
  "egui",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,8 @@ members = [
     "puffin-imgui",
     "puffin_viewer",
 ]
+
+
+[patch.crates-io]
+eframe = { git = "https://github.com/emilk/egui", rev = "faf104220be18cda878e9864bab3760caa4901d8" } # 2021-07-02
+egui = { git = "https://github.com/emilk/egui", rev = "faf104220be18cda878e9864bab3760caa4901d8" } # 2021-07-02

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Paint flamegrpah top-down
+* Scrollable flamegraph
+* Option to sort threads by name
+* Drag with right mouse button to zoom
+* Toggle play/pause with spacebar
+* More compact UI
+* Show all scopes (even tiny ones)
+
 
 ## [0.8.0]
 

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Paint flamegrpah top-down
+* Paint flamegraph top-down
 * Scrollable flamegraph
 * Option to sort threads by name
 * Drag with right mouse button to zoom

--- a/puffin-imgui/Cargo.toml
+++ b/puffin-imgui/Cargo.toml
@@ -14,6 +14,7 @@ include = [ "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 imgui = { version = "0.7" }
+natord = "1.0.9"
 puffin = { version = "0.5.2", path = "../puffin" }
 serde = { version = "1", features = ["derive"] }
 

--- a/puffin-imgui/examples/imgui.rs
+++ b/puffin-imgui/examples/imgui.rs
@@ -149,7 +149,7 @@ fn main() {
             std::thread::sleep(std::time::Duration::from_millis(10))
         }
 
-        for _ in 0..=1000 {
+        for _ in 0..1000 {
             puffin::profile_scope!("very thin");
         }
 

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -75,7 +75,7 @@ pub struct Paused {
 #[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ProfilerUi {
-    options: Options,
+    pub options: Options,
 
     // interaction:
     #[serde(skip)]
@@ -90,25 +90,25 @@ pub struct ProfilerUi {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
-struct Options {
+pub struct Options {
     // --------------------
     // View:
     /// Controls zoom
-    canvas_width_ns: f32,
+    pub canvas_width_ns: f32,
 
     /// How much we have panned sideways:
-    sideways_pan_in_pixels: f32,
+    pub sideways_pan_in_pixels: f32,
 
     // --------------------
     // Visuals:
     /// Events shorter than this many pixels aren't painted
-    cull_width: f32,
-    rect_height: f32,
-    spacing: f32,
-    rounding: f32,
+    pub cull_width: f32,
+    pub rect_height: f32,
+    pub spacing: f32,
+    pub rounding: f32,
 
     /// Aggregate child scopes with the same id?
-    merge_scopes: bool,
+    pub merge_scopes: bool,
 
     /// Set when user clicks a scope.
     /// First part is `now()`, second is range.

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -322,7 +322,7 @@ impl ProfilerUi {
                 options: &mut self.options,
             };
 
-            paint_timeline(&mut info, min_ns, max_ns);
+            paint_timeline(&mut info, min_ns);
 
             // We paint the threads bottom up
             let mut cursor_y = info.canvas_max.y;
@@ -559,7 +559,7 @@ fn now() -> f64 {
         .as_secs_f64()
 }
 
-fn paint_timeline(info: &mut Info<'_>, start_ns: NanoSecond, stop_ns: NanoSecond) {
+fn paint_timeline(info: &mut Info<'_>, start_ns: NanoSecond) {
     if info.options.canvas_width_ns <= 0.0 {
         return;
     }
@@ -583,9 +583,6 @@ fn paint_timeline(info: &mut Info<'_>, start_ns: NanoSecond, stop_ns: NanoSecond
     let mut grid_ns = 0;
 
     loop {
-        if start_ns + grid_ns > stop_ns {
-            break; // stop grid where data stops
-        }
         let line_x = info.pixel_from_ns(info.options, start_ns + grid_ns);
         if line_x > info.canvas_max.x {
             break;

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -414,7 +414,10 @@ impl ProfilerUi {
 
             draw_list.with_clip_rect_intersect(content_min.into(), content_max.into(), || {
                 let max_y = self.ui_canvas(&info, &frame, (min_ns, max_ns));
-                let used_space = Vec2::new(content_region_avail.x, max_y - content_min.y);
+                let used_space = Vec2::new(
+                    content_region_avail.x,
+                    content_region_avail.y.max(max_y - content_min.y),
+                );
 
                 // An invisible button for the canvas allows us to catch input for it.
                 ui.invisible_button(im_str!("canvas"), used_space.into());

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -103,6 +103,9 @@ pub struct Options {
     // Visuals:
     /// Events shorter than this many pixels aren't painted
     pub cull_width: f32,
+    /// Draw each item with at least this width (only makes sense if [`cull_width`] is 0)
+    pub min_width: f32,
+
     pub rect_height: f32,
     pub spacing: f32,
     pub rounding: f32,
@@ -122,7 +125,10 @@ impl Default for Options {
             canvas_width_ns: 0.0,
             sideways_pan_in_pixels: 0.0,
 
-            cull_width: 0.5,
+            // cull_width: 0.5, // save some CPU?
+            cull_width: 0.0, // no culling
+            min_width: 0.5,
+
             rect_height: 16.0,
             spacing: 4.0,
             rounding: 4.0,
@@ -700,11 +706,20 @@ fn paint_record(
     record: &Record<'_>,
     top_y: f32,
 ) -> PaintResult {
-    let start_x = info.pixel_from_ns(options, record.start_ns);
-    let stop_x = info.pixel_from_ns(options, record.stop_ns());
-    let width = stop_x - start_x;
-    if info.canvas_max.x < start_x || stop_x < info.canvas_min.x || width < options.cull_width {
+    let mut start_x = info.pixel_from_ns(options, record.start_ns);
+    let mut stop_x = info.pixel_from_ns(options, record.stop_ns());
+    if info.canvas_max.x < start_x
+        || stop_x < info.canvas_min.x
+        || stop_x - start_x < options.cull_width
+    {
         return PaintResult::Culled;
+    }
+
+    if stop_x - start_x < options.min_width {
+        // Make sure it is visible:
+        let center = 0.5 * (start_x + stop_x);
+        start_x = center - 0.5 * options.min_width;
+        stop_x = center + 0.5 * options.min_width;
     }
 
     let bottom_y = top_y + options.rect_height;
@@ -740,7 +755,7 @@ fn paint_record(
         .rounding(options.rounding)
         .build();
 
-    let wide_enough_for_text = width > 32.0;
+    let wide_enough_for_text = stop_x - start_x > 32.0;
     if wide_enough_for_text {
         let rect_min = rect_min.max(info.canvas_min);
         let rect_max = rect_max.min(info.canvas_max);

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -328,7 +328,7 @@ impl ProfilerUi {
             let mut cursor_y = info.canvas_max.y;
             cursor_y -= info.font_size; // Leave room for time labels
 
-            for (thread_info, stream) in &frame.thread_streams {
+            for (thread_info, stream_info) in &frame.thread_streams {
                 // Visual separator between threads:
                 info.draw_list
                     .add_line(
@@ -344,15 +344,21 @@ impl ProfilerUi {
                 info.canvas_max.y = cursor_y;
 
                 let mut paint_stream = || -> Result<()> {
-                    let top_scopes = Reader::from_start(stream).read_top_scopes()?;
+                    let top_scopes = Reader::from_start(&stream_info.stream).read_top_scopes()?;
                     if info.options.merge_scopes {
                         let merges = puffin::merge_top_scopes(&top_scopes);
                         for merge in merges {
-                            paint_merge_scope(&mut info, stream, &merge, 0, &mut cursor_y)?;
+                            paint_merge_scope(
+                                &mut info,
+                                &stream_info.stream,
+                                &merge,
+                                0,
+                                &mut cursor_y,
+                            )?;
                         }
                     } else {
                         for scope in top_scopes {
-                            paint_scope(&mut info, stream, &scope, 0, &mut cursor_y)?;
+                            paint_scope(&mut info, &stream_info.stream, &scope, 0, &mut cursor_y)?;
                         }
                     }
                     Ok(())

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -437,7 +437,7 @@ impl ProfilerUi {
             self.options.zoom_to_relative_ns_range = None;
         }
 
-        paint_timeline(&info, &self.options, min_ns);
+        paint_timeline(info, &self.options, min_ns);
 
         // We paint the threads top-down
         let mut cursor_y = info.canvas_min.y - info.ui.scroll_y();
@@ -451,7 +451,7 @@ impl ProfilerUi {
             cursor_y += 2.0;
 
             let text_pos = [info.canvas_min.x, cursor_y];
-            paint_thread_info(&info, thread_info, text_pos);
+            paint_thread_info(info, thread_info, text_pos);
             cursor_y += info.font_size;
 
             // Visual separator between threads:
@@ -469,7 +469,7 @@ impl ProfilerUi {
                     let merges = puffin::merge_top_scopes(&top_scopes);
                     for merge in merges {
                         paint_merge_scope(
-                            &info,
+                            info,
                             &mut self.options,
                             &stream_info.stream,
                             &merge,
@@ -480,7 +480,7 @@ impl ProfilerUi {
                 } else {
                     for scope in top_scopes {
                         paint_scope(
-                            &info,
+                            info,
                             &mut self.options,
                             &stream_info.stream,
                             &scope,

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -15,7 +15,7 @@ include = [ "**/*.rs", "Cargo.toml"]
 [dependencies]
 byteorder = { version = "1" }
 once_cell = "1"
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the egui crate will be documented in this file.
 ## Unreleased
 
 * Update to egui 0.13
-* Paint flamegrpah top-down
+* Paint flamegraph top-down
 * Scrollable flamegraph
 * Option to sort threads by name
 * Drag with right mouse button to zoom

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the egui crate will be documented in this file.
 ## Unreleased
 
 * Update to egui 0.13
+* Paint flamegrpah top-down
+* Scrollable flamegraph
+* Option to sort threads by name
+* Drag with right mouse button to zoom
+* Toggle play/pause with spacebar
+* More compact UI
+* Show all scopes (even tiny ones)
 
 
 ## 0.3.0 - 2021-05-27

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -25,6 +25,7 @@ include = [
 
 [dependencies]
 egui = "0.13"
+natord = "1.0.9"
 once_cell = "1.7"
 puffin = { version = "0.5.2", path = "../puffin" }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/puffin_egui/examples/eframe.rs
+++ b/puffin_egui/examples/eframe.rs
@@ -39,6 +39,10 @@ impl epi::App for ExampleApp {
             std::thread::sleep(std::time::Duration::from_millis(10))
         }
 
+        for _ in 0..=1000 {
+            puffin::profile_scope!("very thin");
+        }
+
         self.frame_counter += 1;
     }
 }

--- a/puffin_egui/examples/eframe.rs
+++ b/puffin_egui/examples/eframe.rs
@@ -39,7 +39,7 @@ impl epi::App for ExampleApp {
             std::thread::sleep(std::time::Duration::from_millis(10))
         }
 
-        for _ in 0..=1000 {
+        for _ in 0..1000 {
             puffin::profile_scope!("very thin");
         }
 

--- a/puffin_egui/examples/eframe.rs
+++ b/puffin_egui/examples/eframe.rs
@@ -25,6 +25,14 @@ impl epi::App for ExampleApp {
         puffin_egui::profiler_window(ctx);
 
         // Give us something to inspect:
+
+        std::thread::Builder::new()
+            .name("Other thread".to_owned())
+            .spawn(|| {
+                sleep_ms(5);
+            })
+            .unwrap();
+
         sleep_ms(14);
         if self.frame_counter % 7 == 0 {
             puffin::profile_scope!("Spike");

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -463,6 +463,9 @@ impl ProfilerUi {
 
         let longest_count = frames.recent.len().max(frames.slowest.len());
 
+        // TODO: in egui 0.14 we can do `egui::Grid::new("frame_grid").num_columns(2)` here
+        // and put the labels on the same row as the frame lists.
+
         ui.label("Recent history:");
         Frame::dark_canvas(ui.style()).show(ui, |ui| {
             self.show_frame_list(ui, &frames.recent, longest_count, &mut hovered_frame);

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -392,9 +392,13 @@ impl ProfilerUi {
                 "Merge children with same ID",
             );
             ui.separator();
-            ui.add(Label::new("Help!").text_color(ui.visuals().widgets.inactive.text_color())).on_hover_text(
-                "Drag to pan. Ctrl/cmd + scroll to zoom. Click to focus. Double-click to reset.",
-            );
+            ui.add(Label::new("Help!").text_color(ui.visuals().widgets.inactive.text_color()))
+                .on_hover_text(
+                    "Drag to pan.\n\
+                Zoom: Ctrl/cmd + scroll, or drag with secondary mouse button.\n\
+                Click on a scope to zoom to it.\n\
+                Double-click to reset view.",
+                );
             ui.separator();
             ui.label(format!(
                 "Current frame: {:.1} ms, {} threads, {} scopes, {:.1} kB",
@@ -656,7 +660,11 @@ impl ProfilerUi {
                 self.options.zoom_to_relative_ns_range = None;
             }
 
-            let zoom_factor = info.ctx.input().zoom_delta_2d().x;
+            let mut zoom_factor = info.ctx.input().zoom_delta_2d().x;
+
+            if response.dragged_by(PointerButton::Secondary) {
+                zoom_factor *= (response.drag_delta().y * 0.01).exp();
+            }
 
             if zoom_factor != 1.0 {
                 self.options.canvas_width_ns /= zoom_factor;

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -378,13 +378,24 @@ impl ProfilerUi {
         let (min_ns, max_ns) = frame.range_ns;
 
         ui.horizontal(|ui| {
+            let play_pause_button_size = Vec2::splat(24.0);
             if self.paused.is_some() {
-                if ui.button("Resume").clicked() {
+                if ui
+                    .add_sized(play_pause_button_size, egui::Button::new("▶"))
+                    .on_hover_text("Show latest data. Toggle with space.")
+                    .clicked()
+                    || ui.input().key_pressed(egui::Key::Space)
+                {
                     self.paused = None;
                 }
             } else {
                 ui.horizontal(|ui| {
-                    if ui.button("Pause").clicked() {
+                    if ui
+                        .add_sized(play_pause_button_size, egui::Button::new("⏸"))
+                        .on_hover_text("Pause on this frame. Toggle with space.")
+                        .clicked()
+                        || ui.input().key_pressed(egui::Key::Space)
+                    {
                         let latest = GlobalProfiler::lock().latest_frame();
                         if let Some(latest) = latest {
                             self.pause_and_select(latest);
@@ -403,7 +414,8 @@ impl ProfilerUi {
                     "Drag to pan.\n\
                 Zoom: Ctrl/cmd + scroll, or drag with secondary mouse button.\n\
                 Click on a scope to zoom to it.\n\
-                Double-click to reset view.",
+                Double-click to reset view.\n\
+                Press spacebar to pause/resume.",
                 );
             ui.separator();
             ui.label(format!(

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -333,8 +333,9 @@ impl ProfilerUi {
             ui.ctx().request_repaint(); // keep refreshing to see latest data
         }
 
-        ScrollArea::auto_sized().show(ui, |ui| {
-            Frame::dark_canvas(ui.style()).show(ui, |ui| {
+        Frame::dark_canvas(ui.style()).show(ui, |ui| {
+            let available_height = ui.max_rect().bottom() - ui.min_rect().bottom();
+            ScrollArea::auto_sized().show(ui, |ui| {
                 let canvas = ui.available_rect_before_wrap();
                 let response = ui.interact(canvas, ui.id(), Sense::click_and_drag());
 
@@ -355,6 +356,9 @@ impl ProfilerUi {
 
                 let mut used_rect = canvas;
                 used_rect.max.y = max_y;
+
+                // Fill out space that we don't use so that the `ScrollArea` doesn't collapse in height:
+                used_rect.max.y = used_rect.max.y.max(used_rect.min.y + available_height);
 
                 let timeline = paint_timeline(&info, used_rect, &self.options, min_ns);
                 info.painter

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -356,7 +356,7 @@ impl ProfilerUi {
                 let mut used_rect = canvas;
                 used_rect.max.y = max_y;
 
-                let timeline = paint_timeline(&info, used_rect, &self.options, min_ns, max_ns);
+                let timeline = paint_timeline(&info, used_rect, &self.options, min_ns);
                 info.painter
                     .set(where_to_put_timeline, Shape::Vec(timeline));
 
@@ -613,7 +613,6 @@ fn paint_timeline(
     canvas: Rect,
     options: &Options,
     start_ns: NanoSecond,
-    stop_ns: NanoSecond,
 ) -> Vec<egui::Shape> {
     let mut shapes = vec![];
 
@@ -640,9 +639,6 @@ fn paint_timeline(
     let mut grid_ns = 0;
 
     loop {
-        if start_ns + grid_ns > stop_ns {
-            break; // stop grid where data stops
-        }
         let line_x = info.point_from_ns(options, start_ns + grid_ns);
         if line_x > canvas.max.x {
             break;

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -114,8 +114,8 @@ pub enum SortBy {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Sorting {
-    sort_by: SortBy,
-    reversed: bool,
+    pub sort_by: SortBy,
+    pub reversed: bool,
 }
 
 impl Default for Sorting {
@@ -198,7 +198,7 @@ pub struct Paused {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "persistence", serde(default))]
 pub struct ProfilerUi {
-    options: Options,
+    pub options: Options,
 
     /// If `None`, we show the latest frames.
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -207,30 +207,30 @@ pub struct ProfilerUi {
 
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-struct Options {
+pub struct Options {
     // --------------------
     // View:
     /// Controls zoom
-    canvas_width_ns: f32,
+    pub canvas_width_ns: f32,
 
     /// How much we have panned sideways:
-    sideways_pan_in_points: f32,
+    pub sideways_pan_in_points: f32,
 
     // --------------------
     // Visuals:
     /// Events shorter than this many points aren't painted
-    cull_width: f32,
+    pub cull_width: f32,
     /// Draw each item with at least this width (only makes sense if [`cull_width`] is 0)
-    min_width: f32,
+    pub min_width: f32,
 
-    rect_height: f32,
-    spacing: f32,
-    rounding: f32,
+    pub rect_height: f32,
+    pub spacing: f32,
+    pub rounding: f32,
 
     /// Aggregate child scopes with the same id?
-    merge_scopes: bool,
+    pub merge_scopes: bool,
 
-    sorting: Sorting,
+    pub sorting: Sorting,
 
     /// Set when user clicks a scope.
     /// First part is `now()`, second is range.


### PR DESCRIPTION
### Description of Changes

For both `puffin_egui` and `puffin-imgui`:

* Paint flamegraph top-down
* Scrollable flamegraph
* Option to sort threads by name
* Drag with right mouse button to zoom
* Toggle play/pause with spacebar
* More compact UI
* Show all scopes (even tiny ones)

<img width="654" alt="Screen Shot 2021-07-05 at 12 39 14" src="https://user-images.githubusercontent.com/1148717/124459124-1c9bd000-dd8e-11eb-8859-cce7c1617521.png">

<img width="800" alt="Screen Shot 2021-07-05 at 12 38 14" src="https://user-images.githubusercontent.com/1148717/124459133-1efe2a00-dd8e-11eb-84a0-2e138fbb32a3.png">

### Related Issues

Closes https://github.com/EmbarkStudios/puffin/issues/24
Closes https://github.com/EmbarkStudios/puffin/issues/28
