### PR TITLE
Add file export support + more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * New `serialization` feature flag enables exporting and importing `.puffin` files. This replaces the old `with_serde` feature flag.
+* Add `GlobalProfiler::add_sink` for installing callbacks that are called each frame.
 
 * Speed up `GlobalProfiler::new_frame`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,28 @@
 # Changelog
+
 All notable changes to `puffin` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
+* New `serialization` feature flag enables exporting and importing `.puffin` files. This replaces the old `with_serde` feature flag.
 
 * Speed up `GlobalProfiler::new_frame`.
 
 
 ## 0.6.0 - 2021-07-05
-
 * Handle Windows, which uses backslash (`\`) as path separator.
 
 
 ## 0.5.2
-
 * Add opt-in `serde` support.
 
 
 ## 0.5.1
-
 * Remove stderr warning about empty frames.
 
 
 ## 0.5.0
-
 * `GlobalProfiler` now store recent history and the slowest frames.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,8 @@ dependencies = [
 name = "puffin"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
+ "bincode",
  "byteorder",
  "criterion",
  "once_cell",
@@ -1950,7 +1952,6 @@ name = "puffin_http"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bincode",
  "log",
  "puffin",
  "retain_mut",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827b976d911b5d2e42b2ccfc7c0d2461a1414e8280436885218762fc529b3f8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "macroquad"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +1925,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "criterion",
+ "lz4_flex",
  "once_cell",
  "serde",
 ]
@@ -2367,6 +2377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2474,16 @@ name = "ttf-parser"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f58a822f08abdaf668897e96a5656fe72f5a9ce66422423e8849384872e6"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to `puffin-imgui` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
+* Fix "Toggle with spacebar." tooltip always showing.
+* Show frame index.
 
 
 ## 0.9.0
-
 * Paint flamegraph top-down
 * Scrollable flamegraph
 * Option to sort threads by name
@@ -19,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## 0.8.0
-
 * Select frames from recent history or from among the slowest ever.
 * Nicer colors.
 * Simpler interaction (drag to pan, scroll to zoom, click to focus, double-click to reset).

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -381,7 +381,8 @@ impl ProfilerUi {
         );
 
         ui.text(im_str!(
-            "Current frame: {:.1} ms, {} threads, {} scopes, {:.1} kB",
+            "Showing frame #{}, {:.1} ms, {} threads, {} scopes, {:.1} kB",
+            frame.frame_index,
             (max_ns - min_ns) as f64 * 1e-6,
             frame.thread_streams.len(),
             frame.num_scopes,

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -370,7 +370,7 @@ impl ProfilerUi {
                 }
             }
         }
-        if ui.is_any_item_hovered() {
+        if ui.is_item_hovered() {
             ui.tooltip_text("Toggle with spacebar.");
         }
 

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = { version = "1" }
 once_cell = "1"
 anyhow = { version = "1", optional = true }
 bincode = { version = "1.3", optional = true }
+lz4_flex = { version = "0.8.2", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
@@ -25,7 +26,7 @@ criterion = "0.3"
 [features]
 default = []
 # Feature for enabling loading/saving data to a binary stream and/or file.
-serialization = ["anyhow", "bincode", "serde"]
+serialization = ["anyhow", "bincode", "lz4_flex", "serde"]
 
 [[bench]]
 name = "benchmark"

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -15,6 +15,8 @@ include = [ "**/*.rs", "Cargo.toml"]
 [dependencies]
 byteorder = { version = "1" }
 once_cell = "1"
+anyhow = { version = "1", optional = true }
+bincode = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
@@ -22,7 +24,8 @@ criterion = "0.3"
 
 [features]
 default = []
-with_serde = ["serde"]
+# Feature for enabling loading/saving data to a binary stream and/or file.
+serialization = ["anyhow", "bincode", "serde"]
 
 [[bench]]
 name = "benchmark"

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -679,7 +679,7 @@ impl GlobalProfiler {
     /// Export profile data as a `.puffin` file.
     #[cfg(feature = "serialization")]
     pub fn save_to_writer(&self, write: &mut impl std::io::Write) -> anyhow::Result<()> {
-        write.write_all(b"puf0")?;
+        write.write_all(b"PUF0")?;
 
         let slowest_frames = self.slowest_frames.iter().map(|f| &f.0);
         let mut frames: Vec<_> = slowest_frames.chain(self.recent_frames.iter()).collect();
@@ -704,8 +704,8 @@ impl GlobalProfiler {
     pub fn load_reader(read: &mut impl std::io::Read) -> anyhow::Result<Self> {
         let mut magic = [0_u8; 4];
         read.read_exact(&mut magic)?;
-        if &magic != b"puf0" {
-            anyhow::bail!("Expected .puffin magic header of 'puf0', found {:?}", magic);
+        if &magic != b"PUF0" {
+            anyhow::bail!("Expected .puffin magic header of 'PUF0', found {:?}", magic);
         }
 
         let mut slf = Self {

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the egui crate will be documented in this file.
 
 ## Unreleased
 
+* Show frame index.
+
 
 ## 0.4.0 - 2021-07-05
 

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -443,7 +443,8 @@ impl ProfilerUi {
                 );
             ui.separator();
             ui.label(format!(
-                "Current frame: {:.1} ms, {} threads, {} scopes, {:.1} kB",
+                "Showing frame #{}, {:.1} ms, {} threads, {} scopes, {:.1} kB",
+                frame.frame_index,
                 (max_ns - min_ns) as f64 * 1e-6,
                 frame.thread_streams.len(),
                 frame.num_scopes,

--- a/puffin_http/CHANGELOG.md
+++ b/puffin_http/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `puffin_http` will be documented in this file.
+
+
+## Unreleased
+* Remove `Server::update` (no longer needed).
+* Compress the TCP stream (approximately 75% bandwidth reduction).
+
+
+## 0.3.0
+* Initial release
+

--- a/puffin_http/Cargo.toml
+++ b/puffin_http/Cargo.toml
@@ -14,9 +14,8 @@ include = [ "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 anyhow = "1"
-bincode = "1.3"
 log = "0.4"
-puffin = { version = "0.6.0", path = "../puffin", features = ["with_serde"] }
+puffin = { version = "0.6.0", path = "../puffin", features = ["serialization"] }
 retain_mut = "0.1.3"
 serde = { version = "1", features = ["derive"] }
 

--- a/puffin_http/examples/server.rs
+++ b/puffin_http/examples/server.rs
@@ -7,7 +7,7 @@ fn main() {
     let server_addr = format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT);
     eprintln!("Serving demo profile data on {}", server_addr);
 
-    let puffin_server = puffin_http::Server::new(&server_addr).unwrap();
+    let _puffin_server = puffin_http::Server::new(&server_addr).unwrap();
 
     puffin::set_scopes_on(true);
 
@@ -16,7 +16,6 @@ fn main() {
     loop {
         puffin::profile_scope!("main_loop");
         puffin::GlobalProfiler::lock().new_frame();
-        puffin_server.update();
 
         // Give us something to inspect:
 

--- a/puffin_http/examples/server.rs
+++ b/puffin_http/examples/server.rs
@@ -11,12 +11,33 @@ fn main() {
 
     puffin::set_scopes_on(true);
 
+    let mut frame_counter = 0;
+
     loop {
         puffin::profile_scope!("main_loop");
         puffin::GlobalProfiler::lock().new_frame();
         puffin_server.update();
 
-        sleep_ms(16);
+        // Give us something to inspect:
+
+        std::thread::Builder::new()
+            .name("Other thread".to_owned())
+            .spawn(|| {
+                sleep_ms(5);
+            })
+            .unwrap();
+
+        sleep_ms(14);
+        if frame_counter % 7 == 0 {
+            puffin::profile_scope!("Spike");
+            std::thread::sleep(std::time::Duration::from_millis(10))
+        }
+
+        for _ in 0..1000 {
+            puffin::profile_scope!("very thin");
+        }
+
+        frame_counter += 1;
     }
 }
 

--- a/puffin_http/src/server.rs
+++ b/puffin_http/src/server.rs
@@ -85,19 +85,13 @@ impl PuffinServerImpl {
     }
 
     pub fn send(&mut self, frame: &puffin::FrameData) -> anyhow::Result<()> {
-        use bincode::Options as _;
-        let mut encoded = bincode::options()
-            .serialize(frame)
-            .context("Encode puffin frame")?;
-
         let mut message = vec![];
         message
             .write_all(&crate::PROTOCOL_VERSION.to_le_bytes())
             .unwrap();
-        message
-            .write_all(&(encoded.len() as u32).to_le_bytes())
-            .unwrap();
-        message.append(&mut encoded);
+        frame
+            .write_into(&mut message)
+            .context("Encode puffin frame")?;
 
         use retain_mut::RetainMut as _;
         self.clients

--- a/puffin_viewer/Cargo.toml
+++ b/puffin_viewer/Cargo.toml
@@ -14,7 +14,7 @@ include = [ "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 puffin_egui = { version = "0.4.1", path = "../puffin_egui" }
-puffin = { version = "0.6.0", path = "../puffin", features = ["with_serde"] }
+puffin = { version = "0.6.0", path = "../puffin", features = ["serialization"] }
 puffin_http = { version = "0.3.0", path = "../puffin_http" }
 
 argh = "0.1"


### PR DESCRIPTION
This adds puffin-level support for exporting `.puffin` files with profile data. The support for this in `puffin_viewer` will need to wait for a new `egui` release (see https://github.com/EmbarkStudios/puffin/pull/36).

This PR also adds LZ4 compression to the TCP stream, simpler `puffin_http::Server` usage, profiler sinks, and some (very) minor GUI improvements.