### PR TITLE
Remove unused serde dependency in puffin_http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,6 @@ dependencies = [
  "anyhow",
  "log",
  "puffin",
- "serde",
  "simple_logger",
 ]
 

--- a/puffin_http/Cargo.toml
+++ b/puffin_http/Cargo.toml
@@ -16,7 +16,6 @@ include = [ "**/*.rs", "Cargo.toml"]
 anyhow = "1"
 log = "0.4"
 puffin = { version = "0.9.0", path = "../puffin", features = ["serialization"] }
-serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 simple_logger = "1.11"


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Removes the unused `serde` dependency in the `puffin_http` crate. Could slightly help with crate build parallelism.