### PR TITLE
Add max_recent_frames argument

### DIFF
--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -89,6 +89,10 @@ struct Arguments {
     /// what .puffin file to open, e.g. `my/recording.puffin`.
     #[argh(positional)]
     file: Option<String>,
+
+    /// maximum number of frames to save in memory
+    #[argh(option)]
+    max_recent_frames: Option<usize>,
 }
 
 fn default_url() -> String {
@@ -119,9 +123,14 @@ fn main() {
             }
         }
     } else {
+        let client = puffin_http::Client::new(opt.url);
+        if let Some(max_recent_frames) = opt.max_recent_frames {
+            client.frame_view()
+                .set_max_recent(max_recent_frames);
+        }
         PuffinViewer {
             profiler_ui: Default::default(),
-            source: Source::Http(puffin_http::Client::new(opt.url)),
+            source: Source::Http(client),
             error: None,
         }
     };


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)

(I am getting an error running cargo fmt,
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src\libcore\option.rs:335:20
```
so I have not run rustfmt on this code. I don't normally use rustfmt, so not sure if my setup or rustfmt is broken?)

* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds `--max_recent_frames` argument to CLI to set the maximum number of frames. Only makes sense to me for HTTP version.

**Note:** It looks like the recent frames view behaves weirdly when the max_recent_frames is less than 18,000 (the default) - it starts on the left alright, then jumps to the right (with varying amounts of blank space on the left), then back to the right looking good, seemingly at random. Probably related to something in the EGUI renderer buffering & clearing at intervals or on some event?

![image](https://user-images.githubusercontent.com/53348468/141718404-a593a6af-ca40-4c52-97a7-f9df8a4797d3.png)

### Related Issues

This is an enhancement. The viewer was eating my memory when using the defaults, 80% of the time I don't want the last 5-10 hours of frames...
