### PR TITLE
In-memory compression of frame data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+* In-memory compression of frames to use up less RAM.
 
 
 ## 0.11.0 - 2021-11-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,7 @@ dependencies = [
  "criterion",
  "lz4_flex",
  "once_cell",
+ "parking_lot",
  "serde",
  "zstd",
 ]

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+* In-memory compression of frames to use up less RAM.
 
 
 ## 0.14.0 - 2021-11-12

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -176,8 +176,8 @@ impl Frames {
     fn all_uniq(&self) -> Vec<Arc<FrameData>> {
         let mut all = self.slowest.clone();
         all.extend(self.recent.iter().cloned());
-        all.sort_by_key(|frame| frame.frame_index);
-        all.dedup_by_key(|frame| frame.frame_index);
+        all.sort_by_key(|frame| frame.frame_index());
+        all.dedup_by_key(|frame| frame.frame_index());
         all
     }
 }
@@ -381,7 +381,7 @@ impl ProfilerUi {
     }
 
     fn selected_frame_index(&self) -> Option<FrameIndex> {
-        self.selected_frame().map(|frame| frame.frame_index)
+        self.selected_frame().map(|frame| frame.frame_index())
     }
 
     /// Show the profiler.
@@ -421,7 +421,7 @@ impl ProfilerUi {
 
         // TODO: show age of data
 
-        let (min_ns, max_ns) = frame.range_ns;
+        let (min_ns, max_ns) = frame.range_ns();
 
         ui.button("Help!");
         if ui.is_item_hovered() {
@@ -465,11 +465,11 @@ impl ProfilerUi {
 
         ui.text(format!(
             "Showing frame #{}, {:.1} ms, {} threads, {} scopes, {:.1} kB",
-            frame.frame_index,
+            frame.frame_index(),
             (max_ns - min_ns) as f64 * 1e-6,
             frame.thread_streams.len(),
-            frame.num_scopes,
-            frame.num_bytes as f64 * 1e-3
+            frame.meta.num_scopes,
+            frame.meta.num_bytes as f64 * 1e-3
         ));
 
         // The number of threads can change between frames, so always show this even if there currently is only one thread:
@@ -599,7 +599,7 @@ impl ProfilerUi {
 
         {
             let uniq = frames.all_uniq();
-            let bytes: usize = uniq.iter().map(|frame| frame.num_bytes).sum();
+            let bytes: usize = uniq.iter().map(|frame| frame.meta.num_bytes).sum();
             ui.text(format!(
                 "{} frames recorded ({:.1} MB)",
                 uniq.len(),
@@ -701,7 +701,7 @@ impl ProfilerUi {
                     let duration = frame.duration_ns();
                     slowest_visible_frame = duration.max(slowest_visible_frame);
 
-                    let is_selected = Some(frame.frame_index) == selected_frame_index;
+                    let is_selected = Some(frame.frame_index()) == selected_frame_index;
 
                     let is_hovered = rect_min.x - 0.5 * frame_spacing <= mouse_pos.x
                         && mouse_pos.x < rect_max.x + 0.5 * frame_spacing

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -473,12 +473,11 @@ impl ProfilerUi {
         );
 
         ui.text(format!(
-            "Showing frame #{}, {:.1} ms, {} threads, {} scopes, {:.1} kB",
+            "Showing frame #{}, {:.1} ms, {} threads, {} scopes.",
             frame.frame_index(),
             (max_ns - min_ns) as f64 * 1e-6,
             frame.thread_streams.len(),
             frame.meta.num_scopes,
-            frame.meta.num_bytes as f64 * 1e-3
         ));
 
         // The number of threads can change between frames, so always show this even if there currently is only one thread:

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -363,12 +363,12 @@ impl ProfilerUi {
     }
 
     /// Pause on the specific frame
-    fn pause_and_select(&mut self, selected: Arc<FrameData>) {
+    fn pause_and_select(&mut self, selected_frame: Arc<FrameData>) {
         if let Some(paused) = &mut self.paused {
-            paused.selected_frame = selected;
+            paused.selected_frame = selected_frame;
         } else {
             self.paused = Some(Paused {
-                selected_frame: selected,
+                selected_frame,
                 frames: self.frames(),
             });
         }

--- a/puffin-imgui/src/ui.rs
+++ b/puffin-imgui/src/ui.rs
@@ -608,10 +608,17 @@ impl ProfilerUi {
 
         {
             let uniq = frames.all_uniq();
-            let bytes: usize = uniq.iter().map(|frame| frame.meta.num_bytes).sum();
+
+            let mut bytes = 0;
+            let mut unpacked = 0;
+            for frame in &uniq {
+                bytes += frame.bytes_of_ram_used();
+                unpacked += frame.has_unpacked() as usize;
+            }
             ui.text(format!(
-                "{} frames recorded ({:.1} MB)",
+                "{} frames ({} unpacked) using approximately {:.1} MB.",
                 uniq.len(),
+                unpacked,
                 bytes as f64 * 1e-6
             ));
 

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -15,6 +15,7 @@ include = [ "**/*.rs", "Cargo.toml"]
 [dependencies]
 byteorder = { version = "1" }
 once_cell = "1"
+parking_lot = "0.11"
 
 # Optional:
 anyhow = { version = "1", optional = true }

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -1,4 +1,4 @@
-use crate::{DecompressedFrameData, NanoSecond, Reader, Result, Scope, Stream, ThreadInfo};
+use crate::{NanoSecond, Reader, Result, Scope, Stream, ThreadInfo, UnpackedFrameData};
 use std::collections::BTreeMap;
 
 /// Temporary structure while building a `MergeScope`.
@@ -137,7 +137,7 @@ fn build<'s>(nodes: BTreeMap<&'s str, MergeNode<'s>>, num_frames: i64) -> Vec<Me
 
 /// For the given thread, merge all scopes with the same id path.
 pub fn merge_scopes_for_thread<'s>(
-    frames: &'s [std::sync::Arc<DecompressedFrameData>],
+    frames: &'s [std::sync::Arc<UnpackedFrameData>],
     thread_info: &ThreadInfo,
 ) -> Result<Vec<MergeScope<'s>>> {
     let mut top_nodes: BTreeMap<&'s str, MergeNode<'s>> = Default::default();
@@ -198,7 +198,7 @@ fn test_merge() {
         name: "main".to_owned(),
     };
     thread_streams.insert(thread_info.clone(), stream_info);
-    let frame = DecompressedFrameData::new(0, thread_streams).unwrap();
+    let frame = UnpackedFrameData::new(0, thread_streams).unwrap();
     let frames = [Arc::new(frame)];
     let merged = merge_scopes_for_thread(&frames, &thread_info).unwrap();
 

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -144,7 +144,7 @@ pub fn merge_scopes_for_thread<'s>(
 
     for frame in frames {
         if let Some(stream_info) = frame.thread_streams.get(thread_info) {
-            let offset_ns = frame.range_ns.0 - frames[0].range_ns.0; // make everything relative to first frame
+            let offset_ns = frame.meta.range_ns.0 - frames[0].meta.range_ns.0; // make everything relative to first frame
 
             let top_scopes = Reader::from_start(&stream_info.stream).read_top_scopes()?;
             for scope in top_scopes {

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -1,4 +1,4 @@
-use crate::{FrameData, NanoSecond, Reader, Result, Scope, Stream, ThreadInfo};
+use crate::{DecompressedFrameData, NanoSecond, Reader, Result, Scope, Stream, ThreadInfo};
 use std::collections::BTreeMap;
 
 /// Temporary structure while building a `MergeScope`.
@@ -137,7 +137,7 @@ fn build<'s>(nodes: BTreeMap<&'s str, MergeNode<'s>>, num_frames: i64) -> Vec<Me
 
 /// For the given thread, merge all scopes with the same id path.
 pub fn merge_scopes_for_thread<'s>(
-    frames: &'s [std::sync::Arc<FrameData>],
+    frames: &'s [std::sync::Arc<DecompressedFrameData>],
     thread_info: &ThreadInfo,
 ) -> Result<Vec<MergeScope<'s>>> {
     let mut top_nodes: BTreeMap<&'s str, MergeNode<'s>> = Default::default();
@@ -198,7 +198,7 @@ fn test_merge() {
         name: "main".to_owned(),
     };
     thread_streams.insert(thread_info.clone(), stream_info);
-    let frame = FrameData::new(0, thread_streams).unwrap();
+    let frame = DecompressedFrameData::new(0, thread_streams).unwrap();
     let frames = [Arc::new(frame)];
     let merged = merge_scopes_for_thread(&frames, &thread_info).unwrap();
 

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -34,7 +34,7 @@ impl FrameView {
 
     pub fn add_frame(&mut self, new_frame: Arc<FrameData>) {
         if let Some(last) = self.recent_frames.back() {
-            if new_frame.frame_index <= last.frame_index {
+            if new_frame.frame_index() <= last.frame_index() {
                 // A frame from the past!?
                 // Likely we are `puffin_viewer`, and the server restarted.
                 // The safe choice is to clear everything:
@@ -79,7 +79,7 @@ impl FrameView {
     /// in chronological order.
     pub fn slowest_frames_chronological(&self) -> Vec<Arc<FrameData>> {
         let mut frames: Vec<_> = self.slowest_frames.iter().map(|f| f.0.clone()).collect();
-        frames.sort_by_key(|frame| frame.frame_index);
+        frames.sort_by_key(|frame| frame.frame_index());
         frames
     }
 
@@ -122,8 +122,8 @@ impl FrameView {
 
         let slowest_frames = self.slowest_frames.iter().map(|f| &f.0);
         let mut frames: Vec<_> = slowest_frames.chain(self.recent_frames.iter()).collect();
-        frames.sort_by_key(|frame| frame.frame_index);
-        frames.dedup_by_key(|frame| frame.frame_index);
+        frames.sort_by_key(|frame| frame.frame_index());
+        frames.dedup_by_key(|frame| frame.frame_index());
 
         for frame in frames {
             frame.write_into(write)?;
@@ -171,7 +171,7 @@ pub fn select_slowest(frames: &[Arc<FrameData>], max: usize) -> Vec<Arc<FrameDat
         }
     }
     let mut slowest: Vec<_> = slowest.drain().map(|x| x.0).collect();
-    slowest.sort_by_key(|frame| frame.frame_index);
+    slowest.sort_by_key(|frame| frame.frame_index());
     slowest
 }
 

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -59,6 +59,12 @@ impl FrameView {
             }
         }
 
+        if let Some(last) = self.recent_frames.back() {
+            // Assume there is a viewer viewing the newest frame,
+            // and compress the previously newest frame to save RAM:
+            last.compress();
+        }
+
         self.recent_frames.push_back(new_frame);
         while self.recent_frames.len() > self.max_recent {
             self.recent_frames.pop_front();

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -62,7 +62,7 @@ impl FrameView {
         if let Some(last) = self.recent_frames.back() {
             // Assume there is a viewer viewing the newest frame,
             // and compress the previously newest frame to save RAM:
-            last.compress();
+            last.pack();
         }
 
         self.recent_frames.push_back(new_frame);

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the egui crate will be documented in this file.
 
 ## Unreleased
 * Show total frames recorded and their total size.
+* In-memory compression of frames to use up less RAM.
 
 
 ## 0.10.3 - 2021-11-08

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -564,10 +564,16 @@ impl ProfilerUi {
 
         {
             let uniq = frames.all_uniq();
-            let bytes: usize = uniq.iter().map(|frame| frame.meta.num_bytes).sum();
+            let mut bytes = 0;
+            let mut unpacked = 0;
+            for frame in &uniq {
+                bytes += frame.bytes_of_ram_used();
+                unpacked += frame.has_unpacked() as usize;
+            }
             ui.label(format!(
-                "{} frames recorded ({:.1} MB)",
+                "{} frames ({} unpacked) using approximately {:.1} MB.",
                 uniq.len(),
+                unpacked,
                 bytes as f64 * 1e-6
             ));
         }

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -1,6 +1,6 @@
 use puffin::*;
 
-pub fn ui(ui: &mut egui::Ui, frames: &[std::sync::Arc<FrameData>]) {
+pub fn ui(ui: &mut egui::Ui, frames: &[std::sync::Arc<UnpackedFrameData>]) {
     let mut threads = std::collections::HashSet::<&ThreadInfo>::new();
     let mut stats = Stats::default();
 

--- a/puffin_http/CHANGELOG.md
+++ b/puffin_http/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `puffin_http` will be documented in this file.
 
 
 ## Unreleased
+* In-memory compression of frames to use up less RAM.
 
 
 ## 0.8.0 - 2021-11-12

--- a/puffin_viewer/CHANGELOG.md
+++ b/puffin_viewer/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `puffin_viewer` will be documented in this file.
 
 
 ## Unreleased
+* In-memory compression of frames to use up less RAM.
 
 
 ## 0.9.2 - 2021-11-08

--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
                 error: None,
             },
             Err(err) => {
-                log::error!("Failed to load {}: {}", path.display(), err);
+                log::error!("Failed to load {:?}: {}", path.display(), err);
                 std::process::exit(1);
             }
         }
@@ -203,7 +203,7 @@ impl PuffinViewer {
                 self.error = None;
             }
             Err(err) => {
-                self.error = Some(format!("Failed to load {}: {}", path.display(), err));
+                self.error = Some(format!("Failed to load {:?}: {}", path.display(), err));
             }
         }
     }


### PR DESCRIPTION
This will compress each `FrameData` in-memory, so that puffin use much less RAM. On real-world profiling data you can now fit in 6x more frames into the same amount of memory.

Furthermore, when loading a large `.puffin` recording with `puffin_viewer`, each frame will only be decoded once actually viewed, which does not only save a lot of memory, but also makes the file load _a lot_ faster.