### PR TITLE
Make puffin and puffin_egui compile for wasm32 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           command: check
           args: --all-targets
+      - name: cargo check wasm32
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p puffin_egui --lib --target wasm32-unknown-unknown --all-features
 
   test:
     name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+* Fix compilation for `wasm32-unknown-unknown`.
 
 
 ## 0.12.1 - 2021-11-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "criterion",
  "once_cell",
  "parking_lot",
+ "ruzstd",
  "serde",
  "zstd",
 ]
@@ -2034,6 +2035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cada0ef59efa6a5f4dc5e491f93d9f31e3fc7758df421ff1de8a706338e1100"
+dependencies = [
+ "byteorder",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2395,16 @@ name = "ttf-parser"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e835d06ed78a500d3d0e431a20c18ff5544b3f6e11376e834370cfd35e8948e"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/check.sh
+++ b/check.sh
@@ -7,6 +7,7 @@ set -eux
 cargo check --workspace --all-targets
 cargo test --workspace --doc
 cargo check --workspace --all-targets --all-features
+cargo check -p puffin_egui --lib --target wasm32-unknown-unknown --all-features
 cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all
 cargo test --workspace --all-targets --all-features
 cargo fmt --all -- --check

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -24,14 +24,18 @@ anyhow = { version = "1", optional = true }
 bincode = { version = "1.3", optional = true }
 parking_lot = { version = "0.11", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
-zstd = { version = "0.9", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+zstd = { version = "0.9", optional = true } # native only
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ruzstd = { version = "0.2.4", optional = true } # works on wasm
 
 [dev-dependencies]
 criterion = "0.3"
 
 [features]
 default = []
-packing = ["anyhow", "bincode", "parking_lot", "serde", "zstd"]
+packing = ["anyhow", "bincode", "parking_lot", "serde", "zstd", "ruzstd"]
 # Feature for enabling loading/saving data to a binary stream and/or file.
 serialization = []
 

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -124,6 +124,7 @@ impl FrameView {
 
     /// Export profile data as a `.puffin` file.
     #[cfg(feature = "serialization")]
+    #[cfg(not(target_arch = "wasm32"))] // compression not supported on wasm
     pub fn save_to_path(&self, path: &std::path::Path) -> anyhow::Result<()> {
         let mut file = std::fs::File::create(path)?;
         self.save_to_writer(&mut file)
@@ -131,6 +132,7 @@ impl FrameView {
 
     /// Export profile data as a `.puffin` file.
     #[cfg(feature = "serialization")]
+    #[cfg(not(target_arch = "wasm32"))] // compression not supported on wasm
     pub fn save_to_writer(&self, write: &mut impl std::io::Write) -> anyhow::Result<()> {
         write.write_all(b"PUF0")?;
 

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the egui crate will be documented in this file.
 
 
 ## Unreleased
+* Fix compilation for `wasm32-unknown-unknown`.
 
 
 ## 0.11.0 - 2021-11-16

--- a/puffin_http/src/lib.rs
+++ b/puffin_http/src/lib.rs
@@ -79,7 +79,11 @@ pub const PROTOCOL_VERSION: u16 = 1;
 pub const DEFAULT_PORT: u16 = 8585;
 
 mod client;
+
+#[cfg(not(target_arch = "wasm32"))]
 mod server;
 
 pub use client::Client;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub use server::Server;


### PR DESCRIPTION
Closes https://github.com/EmbarkStudios/puffin/issues/50

Pulled out from the [`puffin_viewer-web` branch](https://github.com/EmbarkStudios/puffin/compare/puffin_viewer-web?expand=1)
