### PR TITLE
Move credit for the puffin photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,20 @@
     <strong>The friendly little instrumentation profiler for Rust</strong>
   </p>
 
-![Puffin photo by Richard Bartz](puffin.jpg)
+  ![Puffin photo by Richard Bartz](puffin.jpg)
+
+  [(puffin photo by Richard Bartz)](https://en.wikipedia.org/wiki/File:Papageitaucher_Fratercula_arctica.jpg)
 
   <p>
 
-      
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 [![Crates.io](https://img.shields.io/crates/v/puffin.svg)](https://crates.io/crates/puffin)
 [![Docs](https://docs.rs/puffin/badge.svg)](https://docs.rs/puffin)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/puffin/status.svg)](https://deps.rs/repo/github/EmbarkStudios/puffin)
 [![Build Status](https://github.com/EmbarkStudios/puffin/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/puffin/actions?workflow=CI)
-    
+
   </p>
-    
-    
 </div>
 
 ## How to use
@@ -73,8 +72,6 @@ Licensed under either of
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
-
-[Puffin photo by Richard Bartz](https://en.wikipedia.org/wiki/File:Papageitaucher_Fratercula_arctica.jpg)
 
 ### Contribution
 


### PR DESCRIPTION
Make it a bit more visible.

Closes https://github.com/EmbarkStudios/puffin/issues/54

<img width="634" alt="Screen Shot 2022-01-10 at 14 36 49" src="https://user-images.githubusercontent.com/1148717/148775042-dac1b2e2-cabb-43be-a6d1-9c82700cffe0.png">

