### PR TITLE
enable packing feature if serialization required

### DIFF
--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -37,7 +37,7 @@ criterion = "0.3"
 default = []
 packing = ["anyhow", "bincode", "parking_lot", "serde", "zstd", "ruzstd"]
 # Feature for enabling loading/saving data to a binary stream and/or file.
-serialization = []
+serialization = ["packing"]
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
I had tried to use puffin with enabled serialization feature and got list of errors about missing anyhow crate.

Also I have found  message:
```
compile_error!(
144 | |     "If the puffin feature 'serialization' is one, the 'packing' feature must also be enabled!"
145 | | );
```

So it may be suitable to automatically enable "packing" if "serialization" requested.


### Description of Changes

automatically enable "packing" feature with "serialization" one
