### PR TITLE
puffin: Fix `now_ns` intradoc links and wrap more monospace in links

### DIFF
--- a/puffin/src/data.rs
+++ b/puffin/src/data.rs
@@ -187,7 +187,7 @@ impl<'s> Reader<'s> {
         Ok(scopes)
     }
 
-    /// `None` if at end of stream
+    /// [`None`] if at end of stream
     fn peek_u8(&mut self) -> Option<u8> {
         let position = self.0.position();
         let value = self.0.read_u8().ok();

--- a/puffin/src/frame_data.rs
+++ b/puffin/src/frame_data.rs
@@ -158,12 +158,12 @@ compile_error!(
 #[cfg(feature = "packing")]
 pub struct FrameData {
     meta: FrameMeta,
-    /// * `None` if still compressed.
+    /// * [`None`] if still compressed.
     /// * `Some(Err(…))` if there was a problem during unpacking.
     /// * `Some(Ok(…))` if unpacked.
     unpacked_frame: RwLock<Option<anyhow::Result<Arc<UnpackedFrameData>>>>,
     /// [`UnpackedFrameData::thread_streams`], compressed with zstd.
-    /// `None` if not yet compressed.
+    /// [`None`] if not yet compressed.
     packed_zstd_streams: RwLock<Option<Vec<u8>>>,
 }
 
@@ -308,7 +308,7 @@ impl FrameData {
         }
     }
 
-    /// Writes one [`FrameData`] into a stream, prefixed by it's length (u32 le).
+    /// Writes one [`FrameData`] into a stream, prefixed by its length ([`u32`] le).
     #[cfg(not(target_arch = "wasm32"))] // compression not supported on wasm
     #[cfg(feature = "serialization")]
     pub fn write_into(&self, write: &mut impl std::io::Write) -> anyhow::Result<()> {
@@ -331,8 +331,8 @@ impl FrameData {
 
     /// Read the next [`FrameData`] from a stream.
     ///
-    /// `None` is returned if the end of the stream is reached (EOF),
-    /// or an end-of-stream sentinel of 0u32 is read.
+    /// [`None`] is returned if the end of the stream is reached (EOF),
+    /// or an end-of-stream sentinel of `0u32` is read.
     #[cfg(feature = "serialization")]
     pub fn read_next(read: &mut impl std::io::Read) -> anyhow::Result<Option<Self>> {
         use anyhow::Context as _;

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -119,15 +119,15 @@ use std::sync::{
 
 static MACROS_ON: AtomicBool = AtomicBool::new(false);
 
-/// Turn on/off the profiler macros (`profile_function`, `profile_scope` etc).
+/// Turn on/off the profiler macros ([`profile_function`], [`profile_scope`] etc).
 /// When off, these calls take only 1-2 ns to call (100x faster).
-/// This is `false` by default.
+/// This is [`false`] by default.
 pub fn set_scopes_on(on: bool) {
     MACROS_ON.store(on, Ordering::Relaxed);
 }
 
 /// Are the profiler scope macros turned on?
-/// This is `false` by default.
+/// This is [`false`] by default.
 pub fn are_scopes_on() -> bool {
     MACROS_ON.load(Ordering::Relaxed)
 }
@@ -241,7 +241,7 @@ pub struct StreamInfo {
 
     /// The smallest and largest nanosecond value in the stream.
     ///
-    /// The default value is `(NanoSecond::MAX, NanoSecond::MIN)` which indicates an empty stream.
+    /// The default value is ([`NanoSecond::MAX`], [`NanoSecond::MIN`]) which indicates an empty stream.
     pub range_ns: (NanoSecond, NanoSecond),
 }
 
@@ -259,7 +259,7 @@ impl Default for StreamInfo {
 impl StreamInfo {
     /// Parse a stream to count the depth, number of scopes in it etc.
     ///
-    /// Try to avoid calling this, and instead keep score while collecting a `StreamInfo`.
+    /// Try to avoid calling this, and instead keep score while collecting a [`StreamInfo`].
     pub fn parse(stream: Stream) -> Result<StreamInfo> {
         let top_scopes = Reader::from_start(&stream).read_top_scopes()?;
         if top_scopes.is_empty() {
@@ -329,7 +329,7 @@ pub struct StreamInfoRef<'a> {
 
     /// The smallest and largest nanosecond value in the stream.
     ///
-    /// The default value is `(NanoSecond::MAX, NanoSecond::MIN)` which indicates an empty stream.
+    /// The default value is ([`NanoSecond::MAX`], [`NanoSecond::MIN`]) which indicates an empty stream.
     pub range_ns: (NanoSecond, NanoSecond),
 }
 
@@ -368,10 +368,10 @@ impl Default for ThreadProfiler {
 impl ThreadProfiler {
     /// Explicit initialize with custom callbacks.
     ///
-    /// If not called, each thread will use the default nanosecond source (`[now_ns]`)
-    /// and report scopes to the global profiler ([`global_reporter`]).
+    /// If not called, each thread will use the default nanosecond source ([`now_ns()`])
+    /// and report scopes to the global profiler ([`global_reporter()`]).
     ///
-    /// For instance, when compiling for WASM the default timing function (`[now_ns]`) won't work,
+    /// For instance, when compiling for WASM the default timing function ([`now_ns()`]) won't work,
     /// so you'll want to call `puffin::ThreadProfiler::initialize(my_timing_function, puffin::global_reporter);`.
     pub fn initialize(now_ns: NsSource, reporter: ThreadReporter) {
         ThreadProfiler::call(|tp| {
@@ -432,7 +432,7 @@ impl ThreadProfiler {
 
 // ----------------------------------------------------------------------------
 
-/// Add these to [`GlobalProfiler`] with [`GlobalProfiler::add_sink`].
+/// Add these to [`GlobalProfiler`] with [`GlobalProfiler::add_sink()`].
 pub type FrameSink = Box<dyn Fn(Arc<FrameData>) + Send>;
 
 /// Identifies a specific [`FrameSink`] when added to [`GlobalProfiler`].
@@ -440,7 +440,7 @@ pub type FrameSink = Box<dyn Fn(Arc<FrameData>) + Send>;
 pub struct FrameSinkId(u64);
 
 /// Singleton. Collects profiling data from multiple threads
-/// and passes them on to different [`FrameSink`]:s.
+/// and passes them on to different [`FrameSink`]s.
 pub struct GlobalProfiler {
     current_frame_index: FrameIndex,
     current_frame: BTreeMap<ThreadInfo, StreamInfo>,
@@ -518,7 +518,7 @@ impl GlobalProfiler {
 
     /// Tells [`GlobalProfiler`] to call this function with each new finished frame.
     ///
-    /// The returned [`FrameSinkId`] can be used to remove the sink with [`Self::remove_sink`].
+    /// The returned [`FrameSinkId`] can be used to remove the sink with [`Self::remove_sink()`].
     pub fn add_sink(&mut self, sink: FrameSink) -> FrameSinkId {
         let id = self.next_sink_id;
         self.next_sink_id.0 += 1;

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -1,7 +1,7 @@
 use crate::{NanoSecond, Reader, Result, Scope, Stream, ThreadInfo, UnpackedFrameData};
 use std::collections::BTreeMap;
 
-/// Temporary structure while building a `MergeScope`.
+/// Temporary structure while building a [`MergeScope`].
 #[derive(Default)]
 struct MergeNode<'s> {
     /// These are the raw scopes that got merged into us.

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{FrameData, FrameSinkId};
 
-/// A view of recent and slowest frames, used by GUI:s.
+/// A view of recent and slowest frames, used by GUIs.
 #[derive(Clone)]
 pub struct FrameView {
     /// newest first
@@ -80,7 +80,7 @@ impl FrameView {
         self.recent.iter()
     }
 
-    /// The slowest frames so far (or since last call to [`Self::clear_slowest`])
+    /// The slowest frames so far (or since last call to [`Self::clear_slowest()`])
     /// in chronological order.
     pub fn slowest_frames_chronological(&self) -> Vec<Arc<FrameData>> {
         let mut frames: Vec<_> = self.slowest.iter().map(|f| f.0.clone()).collect();


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Including some opinionated insertions of `()` at the end of function
links, such that rustdoc enforces these to point to functions only, and
as an indication to the reader that the link points to a function.
