### PR TITLE
Add CI test for default features and fix default features compile error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libxkbcommon-dev # egui_glium dependencies
           sudo apt-get install libgtk-3-dev # rfd dependencies
+      - name: cargo test build default features
+        run: cargo build --tests --release
       - name: cargo test build
         run: cargo build --tests --release --all-features
       - name: cargo test

--- a/puffin/src/frame_data.rs
+++ b/puffin/src/frame_data.rs
@@ -488,5 +488,6 @@ fn decode_zstd(mut bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
     Ok(decoded)
 }
 
+#[cfg(feature = "packing")]
 #[cfg(all(not(feature = "zstd"), not(feature = "ruzstd")))]
 compile_error!("Either feature zstd or ruzstd must be enabled");


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/puffin/issues/65 and adds a test that runs with default features to prevent this from happening again.