### PR TITLE
Add tracing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2316,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "puffin_tracing"
+version = "0.1.0"
+dependencies = [
+ "eframe",
+ "puffin",
+ "puffin_egui",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "puffin_viewer"
 version = "0.12.0"
 dependencies = [
@@ -2673,6 +2694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +2981,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec 1.8.0",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3016,6 +3081,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "puffin_egui",
     "puffin_http",
     "puffin-imgui",
+    "puffin_tracing",
     "puffin_viewer",
 ]
 

--- a/puffin_tracing/Cargo.toml
+++ b/puffin_tracing/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "puffin_tracing"
+version = "0.1.0"
+authors = ["Embark <opensource@embark-studios.com>"]
+description = "A tracing-subscriber layer for puffin integration."
+license = "MIT OR Apache-2.0"
+edition = "2021"
+homepage = "https://github.com/EmbarkStudios/puffin"
+repository = "https://github.com/EmbarkStudios/puffin"
+readme = "README.md"
+categories = ["development-tools::profiling", "gui"]
+keywords = ["profiler", "instrumentation", "gamedev"]
+include = ["**/*.rs", "Cargo.toml", "README.md"]
+
+[dependencies]
+tracing-core = "0.1.26"
+tracing-subscriber = {version = "0.3.1", features = ["registry"]}
+puffin = { version = "0.13.1", path = "../puffin", default-features = false }
+
+[dev-dependencies]
+eframe = "0.18.0"
+puffin_egui = { version = "0.15.0", path = "../puffin_egui" }
+tracing = "0.1.34"

--- a/puffin_tracing/README.md
+++ b/puffin_tracing/README.md
@@ -1,0 +1,30 @@
+# puffin tracing
+
+[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
+[![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
+[![Crates.io](https://img.shields.io/crates/v/puffin_tracing.svg)](https://crates.io/crates/puffin_viewer)
+
+Use [`puffin_tracing`](https://github.com/EmbarkStudios/puffin/tree/main/puffin_tracing) as a layer for tracing-subscriber:
+
+``` rust
+use puffin_tracing::PuffinLayer;
+use tracing::info_span;
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+fn main() {
+    let subscriber = Registry::default().with(PuffinLayer::new());
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    puffin::set_scopes_on(true);
+
+    // ...
+}
+
+fn my_function() {
+    let _span = info_span!("My Function");
+}
+```
+
+See the [`tracing.rs`](examples/tracing.rs) example for how to use it with `tracing` and `eframe`.
+
+To try it out, run `cargo run --release --example tracing`

--- a/puffin_tracing/examples/tracing.rs
+++ b/puffin_tracing/examples/tracing.rs
@@ -1,0 +1,69 @@
+use eframe::egui;
+use puffin_tracing::PuffinLayer;
+use tracing::info_span;
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+fn main() {
+    let subscriber = Registry::default().with(PuffinLayer::new());
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    puffin::set_scopes_on(true); // Remember to call this, or puffin will be disabled!
+
+    let native_options = Default::default();
+    eframe::run_native(
+        "puffin egui eframe",
+        native_options,
+        Box::new(|_cc| Box::new(ExampleApp::default())),
+    );
+}
+
+#[derive(Default)]
+pub struct ExampleApp {
+    frame_counter: u64,
+}
+
+impl eframe::App for ExampleApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        puffin::profile_function!();
+        puffin::GlobalProfiler::lock().new_frame(); // call once per frame!
+
+        puffin_egui::profiler_window(ctx);
+
+        // Give us something to inspect:
+
+        std::thread::Builder::new()
+            .name("Other thread".to_owned())
+            .spawn(|| {
+                sleep_ms(5);
+            })
+            .unwrap();
+
+        sleep_ms(14);
+        if self.frame_counter % 49 == 0 {
+            let _span = info_span!("Spike", millis = 20).entered();
+            std::thread::sleep(std::time::Duration::from_millis(20))
+        }
+        if self.frame_counter % 343 == 0 {
+            let _span = info_span!("Big spike", millis = 50).entered();
+            std::thread::sleep(std::time::Duration::from_millis(50))
+        }
+
+        for _ in 0..1000 {
+            puffin::profile_scope!("very thin");
+        }
+
+        self.frame_counter += 1;
+    }
+}
+
+fn sleep_ms(ms: usize) {
+    puffin::profile_function!();
+    match ms {
+        0 => {}
+        1 => std::thread::sleep(std::time::Duration::from_millis(1)),
+        _ => {
+            sleep_ms(ms / 2);
+            sleep_ms(ms - (ms / 2));
+        }
+    }
+}

--- a/puffin_tracing/src/lib.rs
+++ b/puffin_tracing/src/lib.rs
@@ -1,0 +1,225 @@
+//! A layer to integrate puffin as a tracing subscriber.
+//!
+//! ```
+//! use puffin_tracing::PuffinLayer;
+//! use tracing::info_span;
+//! use tracing_subscriber::{layer::SubscriberExt, Registry};
+//!
+//! fn main() {
+//!     let subscriber = Registry::default().with(PuffinLayer::new());
+//!     tracing::subscriber::set_global_default(subscriber).unwrap();
+//!
+//!     puffin::set_scopes_on(true);
+//!
+//!     // ...
+//! }
+//!
+//! fn my_function() {
+//!     let _span = info_span!("My Function");
+//! }
+//! ```
+
+// BEGIN - Embark standard lints v5 for Rust 1.55+
+// do not change or add/remove here, but one can add exceptions after this section
+// for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::await_holding_lock,
+    clippy::char_lit_as_u8,
+    clippy::checked_conversions,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::disallowed_methods,
+    clippy::disallowed_types,
+    clippy::doc_markdown,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::exit,
+    clippy::expl_impl_clone_on_copy,
+    clippy::explicit_deref_methods,
+    clippy::explicit_into_iter_loop,
+    clippy::fallible_impl_from,
+    clippy::filter_map_next,
+    clippy::flat_map_option,
+    clippy::float_cmp_const,
+    clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
+    clippy::if_let_mutex,
+    clippy::implicit_clone,
+    clippy::imprecise_flops,
+    clippy::inefficient_to_string,
+    clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
+    clippy::large_types_passed_by_value,
+    clippy::let_unit_value,
+    clippy::linkedlist,
+    clippy::lossy_float_literal,
+    clippy::macro_use_imports,
+    clippy::manual_ok_or,
+    clippy::map_err_ignore,
+    clippy::map_flatten,
+    clippy::map_unwrap_or,
+    clippy::match_on_vec_items,
+    clippy::match_same_arms,
+    clippy::match_wild_err_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mem_forget,
+    clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
+    clippy::mut_mut,
+    clippy::mutex_integer,
+    clippy::needless_borrow,
+    clippy::needless_continue,
+    clippy::needless_for_each,
+    clippy::option_option,
+    clippy::path_buf_push_overwrite,
+    clippy::ptr_as_ptr,
+    clippy::rc_mutex,
+    clippy::ref_option_ref,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_functions_in_if_condition,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::string_add_assign,
+    clippy::string_add,
+    clippy::string_lit_as_bytes,
+    clippy::string_to_string,
+    clippy::todo,
+    clippy::trait_duplication_in_bounds,
+    clippy::unimplemented,
+    clippy::unnested_or_patterns,
+    clippy::unused_self,
+    clippy::useless_transmute,
+    clippy::verbose_file_reads,
+    clippy::zero_sized_map_values,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+// crate-specific exceptions:
+#![deny(missing_docs)]
+
+use puffin::ThreadProfiler;
+use std::{cell::RefCell, collections::VecDeque};
+use tracing_core::{
+    span::{Attributes, Id, Record},
+    Subscriber,
+};
+use tracing_subscriber::{
+    fmt::{format::DefaultFields, FormatFields, FormattedFields},
+    layer::Context,
+    registry::LookupSpan,
+    Layer,
+};
+
+thread_local! {
+    static PUFFIN_SPAN_STACK: RefCell<VecDeque<(Id, usize)>> =
+        RefCell::new(VecDeque::with_capacity(16));
+}
+
+/// A tracing layer that collects data for puffin.
+pub struct PuffinLayer<F = DefaultFields> {
+    fmt: F,
+}
+
+impl Default for PuffinLayer<DefaultFields> {
+    fn default() -> Self {
+        Self {
+            fmt: DefaultFields::default(),
+        }
+    }
+}
+
+impl PuffinLayer<DefaultFields> {
+    /// Create a new `PuffinLayer`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use a custom field formatting implementation.
+    pub fn with_formatter<F>(self, fmt: F) -> PuffinLayer<F> {
+        let _ = self;
+        PuffinLayer { fmt }
+    }
+}
+
+impl<S, F> Layer<S> for PuffinLayer<F>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    F: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if !puffin::are_scopes_on() {
+            return;
+        }
+
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if extensions.get_mut::<FormattedFields<F>>().is_none() {
+                let mut fields = FormattedFields::<F>::new(String::with_capacity(64));
+                if self.fmt.format_fields(fields.as_writer(), attrs).is_ok() {
+                    extensions.insert(fields);
+                }
+            }
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(fields) = extensions.get_mut::<FormattedFields<F>>() {
+                let _ = self.fmt.add_fields(fields, values);
+            } else {
+                let mut fields = FormattedFields::<F>::new(String::with_capacity(64));
+                if self.fmt.format_fields(fields.as_writer(), values).is_ok() {
+                    extensions.insert(fields);
+                }
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if !puffin::are_scopes_on() {
+            return;
+        }
+
+        if let Some(span_data) = ctx.span(id) {
+            let metadata = span_data.metadata();
+            let name = metadata.name();
+            let target = metadata.target();
+            let extensions = span_data.extensions();
+            let data = extensions
+                .get::<FormattedFields<F>>()
+                .map(|fields| fields.fields.as_str())
+                .unwrap_or_default();
+
+            ThreadProfiler::call(|tp| {
+                let start_stream_offset = tp.begin_scope(name, target, data);
+                PUFFIN_SPAN_STACK.with(|s| {
+                    s.borrow_mut().push_back((id.clone(), start_stream_offset));
+                });
+            });
+        }
+    }
+
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        PUFFIN_SPAN_STACK.with(|s| {
+            let value = s.borrow_mut().pop_back();
+            if let Some((last_id, start_stream_offset)) = value {
+                if *id == last_id {
+                    ThreadProfiler::call(|tp| tp.end_scope(start_stream_offset));
+                } else {
+                    s.borrow_mut().push_back((last_id, start_stream_offset));
+                }
+            }
+        });
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id) {
+            span.extensions_mut().remove::<FormattedFields<F>>();
+        }
+    }
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This adds a new crate implementing integration with `tracing`. This will let puffin users benefit from other libraries that generate spans with the `tracing` crate, which I believe is quite extensively used in the Rust ecosystem.

I was initially going to publish it to a separate repository, but I thought it would probably be a better addition to this one, to make sure this integration is always up to date, advertise it as an official one if you see it fit here.. and pass the maintenance burden to you guys. 😄 

I wrote up the documentation a bit hastily, I'm not sure how sufficient it is. So I'm open to suggestions (and I left the edits allowed as well).

And thank you for such an awesome tool. I'm also looking forward to it being used by Bevy, which also relies on `tracing` - so hopefully `tracing` support in `puffin` will make Bevy integration much closer to becoming real.