### PR TITLE
Release `puffin-imgui` 0.17 and `puffin_egui` 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "puffin-imgui"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "glium",
  "imgui",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "puffin_egui"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "eframe",
@@ -2463,9 +2463,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rfd"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e3107b2e81967df7c0617e978dc656795583a73ad0ddbf645ce60109caf8c2"
+checksum = "1f756b55bff8f256a1a8c24dbabb1430ac8110628e418a02e4a1c5ff67179f56"
 dependencies = [
  "block",
  "dispatch",
@@ -3379,15 +3379,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08746b4b7ac95f708b3cccceb97b7f9a21a8916dd47fc99b0e6aaf7208f26fd7"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
 dependencies = [
- "windows_aarch64_msvc 0.35.0",
- "windows_i686_gnu 0.35.0",
- "windows_i686_msvc 0.35.0",
- "windows_x86_64_gnu 0.35.0",
- "windows_x86_64_msvc 0.35.0",
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
 ]
 
 [[package]]
@@ -3405,21 +3405,15 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3bc5134e8ce0da5d64dcec3529793f1d33aee5a51fc2b4662e0f881dd463e6"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.35.0"
+name = "windows_aarch64_msvc"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0343a6f35bf43a07b009b8591b78b10ea03de86b06f48e28c96206cd0f453b50"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3428,10 +3422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.35.0"
+name = "windows_i686_gnu"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acdcbf4ca63d8e7a501be86fee744347186275ec2754d129ddeab7a1e3a02e4"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3440,10 +3434,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.35.0"
+name = "windows_i686_msvc"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893c0924c5a990ec73cd2264d1c0cba1773a929e1a3f5dbccffd769f8c4edebb"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3452,16 +3446,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.35.0"
+name = "windows_x86_64_gnu"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29bd61f32889c822c99a8fdf2e93378bd2fae4d7efd2693fab09fcaaf7eff4b"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "winit"

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+## [0.17.0] - 2022-06-22
+### Changed
+- [PR#87](https://github.com/EmbarkStudios/puffin/pull/87) Only run pack passes if packing is enabled on the view
+
 ## [0.16.0] - 2022-02-07
 ### Changed
 - [PR#64](https://github.com/EmbarkStudios/puffin/pull/64) updated dependencies and cleaned up crate metadata.

--- a/puffin-imgui/Cargo.toml
+++ b/puffin-imgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin-imgui"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 description = "ImGui GUI bindings for the Puffin profiler"
 license = "MIT OR Apache-2.0"

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to the egui crate will be documented in this file.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.16.0] - 2022-06-22
+### Changed
+- [PR#87](https://github.com/EmbarkStudios/puffin/pull/87) Only run pack passes if packing is enabled on the view
+
 ## [0.15.0] - 2022-05-11
 - [PR#74](https://github.com/EmbarkStudios/puffin/pull/74) Update to `egui` 0.18.
 

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin_egui"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Show puffin profiler flamegraph in-game using egui"
 edition = "2018"
@@ -22,7 +22,7 @@ include = [
 
 [dependencies]
 chrono = "0.4"
-egui = "0.18.0"
+egui = "0.18.1"
 natord = "1.0.9"
 once_cell = "1.7"
 puffin = { version = "0.13.3", path = "../puffin", features = ["packing"] }

--- a/puffin_viewer/Cargo.toml
+++ b/puffin_viewer/Cargo.toml
@@ -16,7 +16,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-puffin_egui = { version = "0.15.0", path = "../puffin_egui" }
+puffin_egui = { version = "0.16.0", path = "../puffin_egui" }
 puffin = { version = "0.13.3", path = "../puffin", features = [
     "packing",
     "serialization",
@@ -26,7 +26,7 @@ puffin_http = { version = "0.10.0", path = "../puffin_http" }
 argh = "0.1"
 eframe = { version = "0.18.0", features = ["persistence"] }
 log = "0.4"
-rfd = "0.8.1"
+rfd = "0.8.4"
 simple_logger = "2.1"
 
 # native:


### PR DESCRIPTION
* Only run pack passes if packing is enabled on the view