### PR TITLE
clean: move use std::fmt::Write with other use std

### DIFF
--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -90,8 +90,6 @@
 // crate-specific exceptions:
 #![allow(clippy::float_cmp, clippy::manual_range_contains)]
 
-use std::fmt::Write;
-
 mod flamegraph;
 mod maybe_mut_ref;
 mod stats;
@@ -102,6 +100,7 @@ use egui::*;
 use puffin::*;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Write,
     sync::{Arc, Mutex},
 };
 


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Trivial clean.
regroup all use std::<module> seem cleaner and most Rust fmt compliant.
