### PR TITLE
Set initial window size

### DIFF
--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         format!("127.0.0.1:{}", puffin_http::DEFAULT_PORT)
     }
 
+    use eframe::epaint::Vec2;
     use puffin::FrameView;
     use puffin_viewer::{PuffinViewer, Source};
 
@@ -52,6 +53,7 @@ fn main() {
 
     let native_options = eframe::NativeOptions {
         drag_and_drop_support: true,
+        initial_window_size: Some(Vec2::new(800.0, 400.0)),
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
When one installs puffin, or removes the settings at `AppData\Roaming\puffin viewer\data`, it opens puffin very small. This assures the initial application size is at least 800*400. 