### PR TITLE
Set filter on double click

### DIFF
--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -587,7 +587,7 @@ fn paint_record(
             if rect.contains(mouse_pos) {
                 options.filter.set_filter(record.id.to_string());
             }
-        } 
+        }
     } else {
         if is_hovered && info.response.clicked() {
             options.zoom_to_relative_ns_range = Some((

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -588,16 +588,14 @@ fn paint_record(
                 options.filter.set_filter(record.id.to_string());
             }
         }
-    } else {
-        if is_hovered && info.response.clicked() {
-            options.zoom_to_relative_ns_range = Some((
-                info.ctx.input().time,
-                (
-                    record.start_ns - info.start_ns,
-                    record.stop_ns() - info.start_ns,
-                ),
-            ));
-        }
+    } else if is_hovered && info.response.clicked() {
+        options.zoom_to_relative_ns_range = Some((
+            info.ctx.input().time,
+            (
+                record.start_ns - info.start_ns,
+                record.stop_ns() - info.start_ns,
+            ),
+        ));
     }
 
     let mut rect_color = if is_hovered {

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -98,6 +98,10 @@ impl Filter {
             id.to_lowercase().contains(&self.filter)
         }
     }
+
+    fn set_filter(&mut self, filter: String) {
+        self.filter = filter;
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -578,14 +582,22 @@ fn paint_record(
         false
     };
 
-    if is_hovered && info.response.clicked() {
-        options.zoom_to_relative_ns_range = Some((
-            info.ctx.input().time,
-            (
-                record.start_ns - info.start_ns,
-                record.stop_ns() - info.start_ns,
-            ),
-        ));
+    if info.response.double_clicked() {
+        if let Some(mouse_pos) = info.response.interact_pointer_pos() {
+            if rect.contains(mouse_pos) {
+                options.filter.set_filter(record.id.to_string());
+            }
+        } 
+    } else {
+        if is_hovered && info.response.clicked() {
+            options.zoom_to_relative_ns_range = Some((
+                info.ctx.input().time,
+                (
+                    record.start_ns - info.start_ns,
+                    record.stop_ns() - info.start_ns,
+                ),
+            ));
+        }
     }
 
     let mut rect_color = if is_hovered {

--- a/puffin_http/src/server.rs
+++ b/puffin_http/src/server.rs
@@ -53,7 +53,7 @@ impl Server {
                     if let Err(err) = server_impl.accept_new_clients() {
                         log::warn!("puffin server failure: {}", err);
                     }
-                    if let Err(err) = server_impl.send(&*frame) {
+                    if let Err(err) = server_impl.send(&frame) {
                         log::warn!("puffin server failure: {}", err);
                     }
                 }

--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -24,7 +24,6 @@ fn main() {
         format!("127.0.0.1:{}", puffin_http::DEFAULT_PORT)
     }
 
-    use eframe::epaint::Vec2;
     use puffin::FrameView;
     use puffin_viewer::{PuffinViewer, Source};
 

--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         format!("127.0.0.1:{}", puffin_http::DEFAULT_PORT)
     }
 
+    use eframe::epaint::Vec2;
     use puffin::FrameView;
     use puffin_viewer::{PuffinViewer, Source};
 
@@ -52,6 +53,7 @@ fn main() {
 
     let native_options = eframe::NativeOptions {
         drag_and_drop_support: true,
+        initial_window_size: Some(Vec2::new(800.0, 400.0)),
         ..Default::default()
     };
     eframe::run_native(

--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -53,7 +53,6 @@ fn main() {
 
     let native_options = eframe::NativeOptions {
         drag_and_drop_support: true,
-        initial_window_size: Some(Vec2::new(800.0, 400.0)),
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
- Sets the filter to the scope which was double-clicked. 
- Prevent zooming when double clicking.