### PR TITLE
Show/hide thread lanes and make them collapsible 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2459,6 +2460,7 @@ dependencies = [
  "eframe",
  "egui",
  "egui-macroquad",
+ "indexmap",
  "macroquad",
  "natord",
  "once_cell",

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.7"
 puffin = { version = "0.13.3", path = "../puffin", features = ["packing"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 vec1 = "1.8"
+indexmap = {version="1.9.1", features=["serde"]}
 
 [dev-dependencies]
 eframe = "0.19.0"


### PR DESCRIPTION
Checkboxes for hiding and showing puffin flame graph threads. 

The collection is stored in `Options` as it is nice for it to be saved upon application closing. Also used index map such that order is preserved, we get fast insertion and reading, and only get unique thread entries are shown in thje checkbox list. By storing it in `Options` we do generate an index map that gets extended longer and longer with time as all threads from all profiled puffin files/applications eventually end up in there. Tho as we still iterate through the currently selected frame threads those other threads do not show up in our checkbox list. Think its not to big of a deal. 

New option to disable thread lanes: 

![image](https://user-images.githubusercontent.com/19969910/193780968-2f540ec6-1c1c-4a24-9f86-8f8c91d19a13.png)

![image](https://user-images.githubusercontent.com/19969910/193781265-d5612fb0-2186-4416-a245-e45956e1e4b6.png)

Collapsable threads: 

![image](https://user-images.githubusercontent.com/19969910/193781053-0c611496-0f1f-4b14-87ec-4442a69d5459.png)

