### PR TITLE
Add scope filter to stats window

### DIFF
--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the egui crate will be documented in this file.
 - Add ability to collapse thread lanes.
 - Add ability double click on scope in thread lane applies the scope as filter.
 - [PR#93](https://github.com/EmbarkStudios/puffin/pull/93) Update to `egui` 0.19.
+- Add scope filter option for stats panel.
 
 ## [0.16.0] - 2022-06-22
 ### Changed

--- a/puffin_egui/src/filter.rs
+++ b/puffin_egui/src/filter.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Debug, Default)]
+pub struct Filter {
+    filter: String,
+}
+
+impl Filter {
+    pub fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Scope filter:");
+            ui.text_edit_singleline(&mut self.filter);
+            self.filter = self.filter.to_lowercase();
+            if ui.button("ｘ").clicked() {
+                self.filter.clear();
+            }
+        });
+    }
+
+    /// if true, show everything
+    pub fn is_empty(&self) -> bool {
+        self.filter.is_empty()
+    }
+
+    pub fn include(&self, id: &str) -> bool {
+        if self.filter.is_empty() {
+            true
+        } else {
+            id.to_lowercase().contains(&self.filter)
+        }
+    }
+
+    pub fn set_filter(&mut self, filter: String) {
+        self.filter = filter;
+    }
+}

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -125,7 +125,7 @@ pub struct Options {
     pub flamegraph_threads: IndexMap<String, ThreadVisualizationSettings>,
 
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub filter: Filter,
+    filter: Filter,
 
     /// Set when user clicks a scope.
     /// First part is `now()`, second is range.

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -1,6 +1,7 @@
 use std::vec;
 
 use super::{SelectedFrames, ERROR_COLOR, HOVER_COLOR};
+use crate::filter::Filter;
 use egui::*;
 use indexmap::IndexMap;
 use puffin::*;
@@ -69,41 +70,6 @@ impl Sorting {
                 }
             }
         });
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct Filter {
-    filter: String,
-}
-
-impl Filter {
-    pub fn ui(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Scope filter:");
-            ui.text_edit_singleline(&mut self.filter);
-            self.filter = self.filter.to_lowercase();
-            if ui.button("ｘ").clicked() {
-                self.filter.clear();
-            }
-        });
-    }
-
-    /// if true, show everything
-    fn is_empty(&self) -> bool {
-        self.filter.is_empty()
-    }
-
-    pub fn include(&self, id: &str) -> bool {
-        if self.filter.is_empty() {
-            true
-        } else {
-            id.to_lowercase().contains(&self.filter)
-        }
-    }
-
-    fn set_filter(&mut self, filter: String) {
-        self.filter = filter;
     }
 }
 

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -73,12 +73,12 @@ impl Sorting {
 }
 
 #[derive(Clone, Debug, Default)]
-struct Filter {
+pub struct Filter {
     filter: String,
 }
 
 impl Filter {
-    fn ui(&mut self, ui: &mut egui::Ui) {
+    pub fn ui(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             ui.label("Scope filter:");
             ui.text_edit_singleline(&mut self.filter);
@@ -94,7 +94,7 @@ impl Filter {
         self.filter.is_empty()
     }
 
-    fn include(&self, id: &str) -> bool {
+    pub fn include(&self, id: &str) -> bool {
         if self.filter.is_empty() {
             true
         } else {
@@ -159,7 +159,7 @@ pub struct Options {
     pub flamegraph_threads: IndexMap<String, ThreadVisualizationSettings>,
 
     #[cfg_attr(feature = "serde", serde(skip))]
-    filter: Filter,
+    pub filter: Filter,
 
     /// Set when user clicks a scope.
     /// First part is `now()`, second is range.

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -326,7 +326,9 @@ impl Default for View {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct ProfilerUi {
+    #[cfg_attr(feature = "serde", serde(alias = "options"))]
     pub flamegraph_options: flamegraph::Options,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub stats_options: stats::Options,
 
     pub view: View,

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -90,6 +90,7 @@
 // crate-specific exceptions:
 #![allow(clippy::float_cmp, clippy::manual_range_contains)]
 
+mod filter;
 mod flamegraph;
 mod maybe_mut_ref;
 mod stats;
@@ -132,7 +133,7 @@ static PROFILE_UI: once_cell::sync::Lazy<Mutex<GlobalProfilerUi>> =
 /// Call this from within an [`egui::Window`], or use [`profiler_window`] instead.
 pub fn profiler_ui(ui: &mut egui::Ui) {
     let mut profile_ui = PROFILE_UI.lock().unwrap();
-    
+
     profile_ui.ui(ui);
 }
 
@@ -165,7 +166,6 @@ impl GlobalProfilerUi {
     ///
     /// Call this from within an [`egui::Window`], or use [`Self::window`] instead.
     pub fn ui(&mut self, ui: &mut egui::Ui) {
-        
         let mut frame_view = self.global_frame_view.lock();
         self.profiler_ui
             .ui(ui, &mut MaybeMutRef::MutRef(&mut frame_view));
@@ -603,8 +603,9 @@ impl ProfilerUi {
 
             // Show as many slow frames as we fit in the view:
             Frame::dark_canvas(ui.style()).show(ui, |ui| {
-                let num_fit =
-                    (ui.available_size_before_wrap().x / self.flamegraph_options.frame_width).floor();
+                let num_fit = (ui.available_size_before_wrap().x
+                    / self.flamegraph_options.frame_width)
+                    .floor();
                 let num_fit = (num_fit as usize).at_least(1).at_most(frames.slowest.len());
                 let slowest_of_the_slow = puffin::select_slowest(&frames.slowest, num_fit);
 

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -7,7 +7,7 @@ use crate::filter::Filter;
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Options {
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub filter: Filter,
+    filter: Filter,
 }
 
 pub fn ui(ui: &mut egui::Ui, options: &mut Options, frames: &[std::sync::Arc<UnpackedFrameData>]) {

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -1,11 +1,11 @@
 use puffin::*;
 
-use crate::flamegraph::Filter;
+use crate::filter::Filter;
 
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-pub struct Options {   
+pub struct Options {
     #[cfg_attr(feature = "serde", serde(skip))]
     pub filter: Filter,
 }
@@ -39,11 +39,11 @@ pub fn ui(ui: &mut egui::Ui, options: &mut Options, frames: &[std::sync::Arc<Unp
     ));
 
     ui.separator();
-    
+
     options.filter.ui(ui);
-    
+
     ui.separator();
-        
+
     let mut scopes: Vec<_> = stats
         .scopes
         .iter()

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -3,10 +3,7 @@ use puffin::*;
 use crate::filter::Filter;
 
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(default))]
 pub struct Options {
-    #[cfg_attr(feature = "serde", serde(skip))]
     filter: Filter,
 }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds a scope filter, similar to flamegraph filter, to the stats panel. 

- Moves the `Filter` component out of the flamegraph file.
- Implements the `Filter` component for the stats file to filter scopes.

### Demo
![image](https://user-images.githubusercontent.com/19969910/194817867-7348634e-e71b-457a-be39-cf770c531b0e.png)
