### PR TITLE
Don't merge scopes that have different data

### DIFF
--- a/puffin-imgui/examples/imgui.rs
+++ b/puffin-imgui/examples/imgui.rs
@@ -152,6 +152,18 @@ fn main() {
             puffin::profile_scope!("Big spike");
             std::thread::sleep(std::time::Duration::from_millis(50))
         }
+        if frame_counter % 55 == 0 {
+            // test to verify these spikes timers are not merged together as they have different data
+            for (name, ms) in [("First".to_string(), 20), ("Second".to_string(), 15)] {
+                puffin::profile_scope!("Spike", name);
+                std::thread::sleep(std::time::Duration::from_millis(ms))
+            }
+            // these are however fine to merge together as data is the same
+            for (_name, ms) in [("First".to_string(), 20), ("Second".to_string(), 15)] {
+                puffin::profile_scope!("Spike");
+                std::thread::sleep(std::time::Duration::from_millis(ms))
+            }
+        }
 
         for _ in 0..1000 {
             puffin::profile_scope!("very thin");

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -8,8 +8,8 @@ struct MergeNode<'s> {
     /// All these scopes have the same `id`.
     pieces: Vec<MergePiece<'s>>,
 
-    /// indexed by their id
-    children: BTreeMap<&'s str, MergeNode<'s>>,
+    /// indexed by their id+data
+    children: BTreeMap<(&'s str, &'s str), MergeNode<'s>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -65,13 +65,16 @@ impl<'s> MergeNode<'s> {
 
         for child in Reader::with_offset(stream, piece.scope.child_begin_position)? {
             let child = child?;
-            self.children.entry(child.record.id).or_default().add(
-                stream,
-                MergePiece {
-                    relative_start_ns: child.record.start_ns - piece.scope.record.start_ns,
-                    scope: child,
-                },
-            )?;
+            self.children
+                .entry((child.record.id, child.record.data))
+                .or_default()
+                .add(
+                    stream,
+                    MergePiece {
+                        relative_start_ns: child.record.start_ns - piece.scope.record.start_ns,
+                        scope: child,
+                    },
+                )?;
         }
 
         Ok(())
@@ -116,7 +119,10 @@ impl<'s> MergeNode<'s> {
     }
 }
 
-fn build<'s>(nodes: BTreeMap<&'s str, MergeNode<'s>>, num_frames: i64) -> Vec<MergeScope<'s>> {
+fn build<'s>(
+    nodes: BTreeMap<(&'s str, &'s str), MergeNode<'s>>,
+    num_frames: i64,
+) -> Vec<MergeScope<'s>> {
     let mut scopes: Vec<_> = nodes
         .into_values()
         .map(|node| node.build(num_frames))
@@ -135,12 +141,12 @@ fn build<'s>(nodes: BTreeMap<&'s str, MergeNode<'s>>, num_frames: i64) -> Vec<Me
     scopes
 }
 
-/// For the given thread, merge all scopes with the same id path.
+/// For the given thread, merge all scopes with the same id+data path.
 pub fn merge_scopes_for_thread<'s>(
     frames: &'s [std::sync::Arc<UnpackedFrameData>],
     thread_info: &ThreadInfo,
 ) -> Result<Vec<MergeScope<'s>>> {
-    let mut top_nodes: BTreeMap<&'s str, MergeNode<'s>> = Default::default();
+    let mut top_nodes: BTreeMap<(&'s str, &'s str), MergeNode<'s>> = Default::default();
 
     for frame in frames {
         if let Some(stream_info) = frame.thread_streams.get(thread_info) {
@@ -148,13 +154,16 @@ pub fn merge_scopes_for_thread<'s>(
 
             let top_scopes = Reader::from_start(&stream_info.stream).read_top_scopes()?;
             for scope in top_scopes {
-                top_nodes.entry(scope.record.id).or_default().add(
-                    &stream_info.stream,
-                    MergePiece {
-                        relative_start_ns: scope.record.start_ns - offset_ns,
-                        scope,
-                    },
-                )?;
+                top_nodes
+                    .entry((scope.record.id, scope.record.data))
+                    .or_default()
+                    .add(
+                        &stream_info.stream,
+                        MergePiece {
+                            relative_start_ns: scope.record.start_ns - offset_ns,
+                            scope,
+                        },
+                    )?;
             }
         }
     }

--- a/puffin_egui/examples/eframe.rs
+++ b/puffin_egui/examples/eframe.rs
@@ -41,6 +41,18 @@ impl eframe::App for ExampleApp {
             puffin::profile_scope!("Big spike");
             std::thread::sleep(std::time::Duration::from_millis(50))
         }
+        if self.frame_counter % 55 == 0 {
+            // test to verify these spikes timers are not merged together as they have different data
+            for (name, ms) in [("First".to_string(), 20), ("Second".to_string(), 15)] {
+                puffin::profile_scope!("Spike", name);
+                std::thread::sleep(std::time::Duration::from_millis(ms))
+            }
+            // these are however fine to merge together as data is the same
+            for (_name, ms) in [("First".to_string(), 20), ("Second".to_string(), 15)] {
+                puffin::profile_scope!("Spike");
+                std::thread::sleep(std::time::Duration::from_millis(ms))
+            }
+        }
 
         for _ in 0..1000 {
             puffin::profile_scope!("very thin");


### PR DESCRIPTION
Previously we would merge all scopes that have the same `id`, but if you have multiple scopes after each that have same `id` but different dynamic `data` field they would be merged together and we wouldn't display the `data` field.

This is something we ran into in our codebase that made it harder to see why a certain heavy operation was happening as we were missing the context for it. Which we did specify but was merged together and not shown here as merging scopes is on by default (and is a general good idea).

Adds a simple visual test for in the imgui and e gui clients.
