### PR TITLE
Release `puffin-imgui` 0.18.0 and `puffin_egui` 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "puffin-imgui"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "glium",
  "imgui",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "puffin_egui"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "eframe",

--- a/puffin-imgui/CHANGELOG.md
+++ b/puffin-imgui/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.18.0] - 2022-11-08
+
+- Require `puffin` 0.14.0
+
 ## [0.17.0] - 2022-06-22
 ### Changed
 - [PR#87](https://github.com/EmbarkStudios/puffin/pull/87) Only run pack passes if packing is enabled on the view

--- a/puffin-imgui/Cargo.toml
+++ b/puffin-imgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin-imgui"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 description = "ImGui GUI bindings for the Puffin profiler"
 license = "MIT OR Apache-2.0"

--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the egui crate will be documented in this file.
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+## [0.18.0] - 2022-11-08
+
+- Require `puffin` 0.14.0
+
 ## [0.17.0] - 2022-10-17
 
 - Add ability to hide and show thread lanes.

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puffin_egui"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Show puffin profiler flamegraph in-game using egui"
 edition = "2018"

--- a/puffin_viewer/Cargo.toml
+++ b/puffin_viewer/Cargo.toml
@@ -16,7 +16,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-puffin_egui = { version = "0.17.0", path = "../puffin_egui" }
+puffin_egui = { version = "0.18.0", path = "../puffin_egui" }
 puffin = { version = "0.14.0", path = "../puffin", features = [
     "packing",
     "serialization",


### PR DESCRIPTION
Required follow up to #107 from yesterday.