### PR TITLE
Change chrono dep to time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,19 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75476fe966a8af7c0ceae2a3e514afa87d4451741fcdfab8bfaa07ad301842ec"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time 0.1.43",
- "winapi",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,16 +1697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +1966,6 @@ dependencies = [
 name = "puffin_egui"
 version = "0.19.0"
 dependencies = [
- "chrono",
  "eframe",
  "egui",
  "indexmap",
@@ -1998,6 +1974,7 @@ dependencies = [
  "once_cell",
  "puffin",
  "serde",
+ "time",
  "vec1",
 ]
 
@@ -2285,7 +2262,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.9",
+ "time",
  "winapi",
 ]
 
@@ -2427,31 +2404,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-time = { version = "0.3.17", features = [ "parsing" ] }
+time = { version = "0.3.17", default-features = false, features = [ "parsing" ] }
 egui = { version = "0.20.1", default-features = false, features = ["default_fonts"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
 instant = "0.1"

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+time = { version = "0.3.17", features = [ "parsing" ] }
 egui = { version = "0.20.1", default-features = false, features = ["default_fonts"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
 instant = "0.1"

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -99,6 +99,7 @@ pub use {egui, maybe_mut_ref::MaybeMutRef, puffin};
 
 use egui::*;
 use puffin::*;
+use time::{OffsetDateTime, macros::format_description};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Write as _,
@@ -818,9 +819,12 @@ fn frames_info_ui(ui: &mut egui::Ui, selection: &SelectedFrames) {
 fn format_time(nanos: NanoSecond) -> Option<String> {
     let years_since_epoch = nanos / 1_000_000_000 / 60 / 60 / 24 / 365;
     if 50 <= years_since_epoch && years_since_epoch <= 150 {
-        use chrono::TimeZone as _;
-        let datetime = chrono::Utc.timestamp(nanos / 1_000_000_000, (nanos % 1_000_000_000) as _);
-        Some(datetime.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string())
+        let Ok(offset) = OffsetDateTime::from_unix_timestamp_nanos(nanos as i128) else { return None; };
+      
+        let format_desc = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]..[subsecond digits:3]");
+        let Ok(datetime) = offset.format(&format_desc) else { return None; };
+
+        Some(datetime)
     } else {
         None // `nanos` is likely not counting from epoch.
     }

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -99,12 +99,12 @@ pub use {egui, maybe_mut_ref::MaybeMutRef, puffin};
 
 use egui::*;
 use puffin::*;
-use time::{OffsetDateTime, macros::format_description};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Write as _,
     sync::{Arc, Mutex},
 };
+use time::{macros::format_description, OffsetDateTime};
 
 const ERROR_COLOR: Color32 = Color32::RED;
 const HOVER_COLOR: Rgba = Rgba::from_rgb(0.8, 0.8, 0.8);
@@ -820,8 +820,10 @@ fn format_time(nanos: NanoSecond) -> Option<String> {
     let years_since_epoch = nanos / 1_000_000_000 / 60 / 60 / 24 / 365;
     if 50 <= years_since_epoch && years_since_epoch <= 150 {
         let Ok(offset) = OffsetDateTime::from_unix_timestamp_nanos(nanos as i128) else { return None; };
-      
-        let format_desc = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]..[subsecond digits:3]");
+
+        let format_desc = format_description!(
+            "[year]-[month]-[day] [hour]:[minute]:[second]..[subsecond digits:3]"
+        );
         let Ok(datetime) = offset.format(&format_desc) else { return None; };
 
         Some(datetime)


### PR DESCRIPTION
Reason:
- Chrono depends on very old time 1.43 dep that has security issues.
- By having chrono we require to have two version of time 1.43 and 0.3.9
- Chrono Includes quite a few deps that can be ignored if one only needs to depend on egui puffin. 
- Time is lower level and we only use it for date parsing which can easily be done by time crate only