### PR TITLE
Added a sliding window option for unpaused metrics (puffin_viewer).

### DIFF
--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -83,6 +83,21 @@ impl FrameView {
         self.recent.back().cloned()
     }
 
+    /// Returns up to `n` latest fully captured frames of data.
+    pub fn latest_frames(&self, n: usize) -> Vec<Arc<FrameData>> {
+        // Probably not the best way to do this, but since
+        // [`self.recent`] is immutable in this context and
+        // working with deque slices is complicated, we'll do
+        // it this way for now.
+        self.recent
+            .iter()
+            .rev()
+            .take(n)
+            .rev()
+            .map(|arc| arc.clone())
+            .collect()
+    }
+
     /// Oldest first
     pub fn recent_frames(&self) -> impl Iterator<Item = &Arc<FrameData>> {
         self.recent.iter()


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When using `puffin_http` and `puffin_viewer`, both the flamegraph and stats view can be very jittery and difficult to read without pausing. I've added a slider that controls the number of latest frames used to acquire a more stable realtime view, mainly for my own convenience. Feedback and suggestions appreciated!

### Related Issues

None that I'm aware of.
