### PR TITLE
Fix wasm non-web usage of env::now

### DIFF
--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -564,7 +564,7 @@ pub fn now_ns() -> NanoSecond {
 #[cfg(all(target_arch = "wasm32", not(feature = "web")))]
 pub fn now_ns() -> NanoSecond {
     // This should be unused.
-    0
+    panic!("Wasm without the `web` feature requires passing a custom source of time via `ThreadProfiler::initialize`");
 }
 
 // ----------------------------------------------------------------------------

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -535,17 +535,11 @@ impl GlobalProfiler {
 
 /// Returns a high-precision, monotonically increasing nanosecond count since unix epoch.
 #[inline]
+#[cfg(any(not(target_arch = "wasm32"), feature = "web"))]
 pub fn now_ns() -> NanoSecond {
     #[cfg(target_arch = "wasm32")]
     fn nanos_since_epoch() -> NanoSecond {
-        #[cfg(feature = "web")]
-        {
-            (js_sys::Date::new_0().get_time() * 1e6) as _
-        }
-        #[cfg(not(feature = "web"))]
-        {
-            0 // We won't get correct date-times, but that's fine.
-        }
+        (js_sys::Date::new_0().get_time() * 1e6) as _
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -564,6 +558,13 @@ pub fn now_ns() -> NanoSecond {
     static START_TIME: Lazy<(NanoSecond, Instant)> =
         Lazy::new(|| (nanos_since_epoch(), Instant::now()));
     START_TIME.0 + START_TIME.1.elapsed().as_nanos() as NanoSecond
+}
+
+#[inline]
+#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
+pub fn now_ns() -> NanoSecond {
+    // This should be unused.
+    0
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

A wasm embedder that hasn't enabled the `web` feature will still get the `Instant::now()` function generated, even if they end up using a custom `now` function. After all, the compiler/link don't have runtime knowledge about how the program runs, so it could be that `ThreadProfiler::initialize` is never called, so the default value of `now_ns` that makes use of `Instant::now` could be called at any point.
 
This changes the `now_ns` function so it's defined only using `Instant` for native target and wasm when web is enabled. In the other case, we assume this is never called and it's a programmer error because we don't have any time reporter. I didn't want to cause a `panic!` in there, so returned a dummy value instead; let me know what you think is preferred.

### Related Issues

Fixes #118.
