### PR TITLE
Compression benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1622,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2121,7 @@ dependencies = [
  "insta",
  "instant",
  "js-sys",
+ "lzma-rs",
  "once_cell",
  "parking_lot",
  "ruzstd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +899,12 @@ dependencies = [
  "bytemuck",
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumn"
@@ -1403,6 +1421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea5b3894afe466b4bcf0388630fc15e11938a6074af0cd637c825ba2ec8a099"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1534,12 @@ checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1999,6 +2036,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "criterion",
+ "insta",
  "instant",
  "js-sys",
  "once_cell",
@@ -2334,6 +2372,12 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "simple_logger"
@@ -2975,6 +3019,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -3223,6 +3282,15 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +271,27 @@ checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
 dependencies = [
  "block-sys",
  "objc2-encode",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2034,6 +2070,7 @@ version = "0.14.3"
 dependencies = [
  "anyhow",
  "bincode",
+ "brotli",
  "byteorder",
  "criterion",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.1",
  "object",
  "rustc-demangle",
 ]
@@ -991,6 +991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.6.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,7 +2061,7 @@ dependencies = [
  "bitflags",
  "crc32fast",
  "deflate",
- "miniz_oxide",
+ "miniz_oxide 0.5.1",
 ]
 
 [[package]]
@@ -2073,6 +2092,7 @@ dependencies = [
  "brotli",
  "byteorder",
  "criterion",
+ "flate2",
  "insta",
  "instant",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2127,7 @@ dependencies = [
  "insta",
  "instant",
  "js-sys",
+ "lz4_flex",
  "lzma-rs",
  "once_cell",
  "parking_lot",

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -52,6 +52,7 @@ criterion = "0.4"
 insta = "1.26"
 brotli = "3.3.4"
 flate2 = "1.0"
+lzma-rs = "0.3.0"
 
 
 [[bench]]

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -50,6 +50,8 @@ ruzstd = { version = "0.3.0", optional = true } # works on wasm
 [dev-dependencies]
 criterion = "0.4"
 insta = "1.26"
+brotli = "3.3.4"
+
 
 [[bench]]
 name = "benchmark"

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -51,6 +51,7 @@ ruzstd = { version = "0.3.0", optional = true } # works on wasm
 criterion = "0.4"
 insta = "1.26"
 brotli = "3.3.4"
+flate2 = "1.0"
 
 
 [[bench]]

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -52,6 +52,7 @@ criterion = "0.4"
 insta = "1.26"
 brotli = "3.3.4"
 flate2 = "1.0"
+lz4_flex = { version = "0.10", default-features = false }
 lzma-rs = "0.3.0"
 
 

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -49,6 +49,7 @@ ruzstd = { version = "0.3.0", optional = true } # works on wasm
 
 [dev-dependencies]
 criterion = "0.4"
+insta = "1.26"
 
 [[bench]]
 name = "benchmark"

--- a/puffin/benches/benchmark.rs
+++ b/puffin/benches/benchmark.rs
@@ -1,5 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
+mod compression;
+
 pub fn criterion_benchmark(c: &mut Criterion) {
     puffin::set_scopes_on(true);
     puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
@@ -48,5 +50,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group!(
+    benches,
+    criterion_benchmark,
+    compression::compression_comparison
+);
 criterion_main!(benches);

--- a/puffin/benches/compression.rs
+++ b/puffin/benches/compression.rs
@@ -192,4 +192,23 @@ pub fn compression_comparison(c: &mut Criterion) {
         assert_eq!(decoded, test_stream.bytes());
         assert_debug_snapshot!("brotli encode", report_compression(&test_stream, &encoded));
     }
+    // lz4 via `lz4_flex` crate
+    {
+        let encoded = lz4_flex::compress_prepend_size(test_stream.bytes());
+
+        c.bench_function("lz4_flex encode", |b| {
+            b.iter(|| lz4_flex::compress_prepend_size(test_stream.bytes()))
+        });
+        c.bench_function("lz4_flex decode", |b| {
+            b.iter(|| lz4_flex::decompress_size_prepended(encoded.as_slice()))
+        });
+
+        // sanity & size check
+        let decoded = lz4_flex::decompress_size_prepended(encoded.as_slice()).unwrap();
+        assert_eq!(decoded, test_stream.bytes());
+        assert_debug_snapshot!(
+            "lz4_flex encode",
+            report_compression(&test_stream, &encoded)
+        );
+    }
 }

--- a/puffin/benches/compression.rs
+++ b/puffin/benches/compression.rs
@@ -1,0 +1,79 @@
+use std::hash::Hasher;
+
+use criterion::Criterion;
+use puffin::Stream;
+
+use insta::assert_debug_snapshot;
+
+pub fn create_test_stream() -> Stream {
+    let mut stream = Stream::default();
+
+    // Cycle through a bunch of message ids & location names so it's *absolutely* trivially compressible,
+    // but also has plenty of opportunity to so compress.
+    let id_strings = [
+        "my_function",
+        "something_with_a_really_long_name",
+        "foo",
+        "bar",
+        "hello",
+    ];
+    let message_ids =
+        std::iter::repeat((0..157).map(|i| format!("{}_{i}", id_strings[i % id_strings.len()])))
+            .flatten();
+    let location_strings = [
+        "foobar.rs",
+        "wumpf.rs",
+        "mod.rs",
+        "lib.rs",
+        "compression.rs",
+        "very_ominous_name_for_a_location.rs",
+    ];
+    let locations = std::iter::repeat(
+        (0..173).map(|i| format!("{}:{i}", location_strings[i % location_strings.len()])),
+    )
+    .flatten();
+
+    for (i, (id, location)) in message_ids.zip(locations).enumerate().take(1_000_000) {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hasher.write_usize(i);
+        let data = format!("{}", hasher.finish());
+
+        let start_offset = stream.begin_scope((i * 2) as _, &id, &location, &data);
+        stream.end_scope(start_offset, (i * 2 + 1) as _);
+    }
+
+    stream
+}
+
+fn report_compression(uncompressed: &Stream, compressed: &[u8]) -> String {
+    format!(
+        "{:?}bytes - ratio {:.2}",
+        uncompressed.len(),
+        uncompressed.len() as f32 / compressed.len() as f32
+    )
+}
+
+pub fn compression_comparison(c: &mut Criterion) {
+    let test_stream = create_test_stream();
+
+    // zstd
+    {
+        c.bench_function("zstd encode", |b| {
+            b.iter(|| {
+                zstd::stream::encode_all(test_stream.bytes(), 3).unwrap();
+            })
+        });
+        c.bench_function("zstd decode", |b| {
+            let encoded = zstd::stream::encode_all(test_stream.bytes(), 3).unwrap();
+            b.iter(|| {
+                zstd::stream::decode_all(encoded.as_slice()).unwrap();
+            })
+        });
+
+        // sanity & size check
+        let encoded = zstd::stream::encode_all(test_stream.bytes(), 3).unwrap();
+        let decoded = zstd::stream::decode_all(encoded.as_slice()).unwrap();
+        assert_eq!(decoded, test_stream.bytes());
+        assert_debug_snapshot!("zstd encode", report_compression(&test_stream, &encoded));
+    }
+}

--- a/puffin/benches/snapshots/benchmark__compression__brotli encode.snap
+++ b/puffin/benches/snapshots/benchmark__compression__brotli encode.snap
@@ -1,0 +1,5 @@
+---
+source: puffin/benches/compression.rs
+expression: "report_compression(&test_stream, &encoded)"
+---
+"2286369bytes - ratio 3.46"

--- a/puffin/benches/snapshots/benchmark__compression__gzip (flate2) encode.snap
+++ b/puffin/benches/snapshots/benchmark__compression__gzip (flate2) encode.snap
@@ -1,0 +1,5 @@
+---
+source: puffin/benches/compression.rs
+expression: "report_compression(&test_stream, &encoded)"
+---
+"2650895bytes - ratio 2.98"

--- a/puffin/benches/snapshots/benchmark__compression__lz4_flex encode.snap
+++ b/puffin/benches/snapshots/benchmark__compression__lz4_flex encode.snap
@@ -1,0 +1,6 @@
+---
+source: puffin/benches/compression.rs
+assertion_line: 209
+expression: "report_compression(&test_stream, &encoded)"
+---
+"4022383bytes - ratio 1.97"

--- a/puffin/benches/snapshots/benchmark__compression__lzma (lzma-rs) encode.snap
+++ b/puffin/benches/snapshots/benchmark__compression__lzma (lzma-rs) encode.snap
@@ -1,0 +1,5 @@
+---
+source: puffin/benches/compression.rs
+expression: "report_compression(&test_stream, &encoded)"
+---
+"3664899bytes - ratio 2.16"

--- a/puffin/benches/snapshots/benchmark__compression__zstd encode.snap
+++ b/puffin/benches/snapshots/benchmark__compression__zstd encode.snap
@@ -1,6 +1,5 @@
 ---
 source: puffin/benches/compression.rs
-assertion_line: 77
 expression: "report_compression(&test_stream, &encoded)"
 ---
-"79073128bytes - ratio 3.16"
+"2500288bytes - ratio 3.16"

--- a/puffin/benches/snapshots/benchmark__compression__zstd encode.snap.new
+++ b/puffin/benches/snapshots/benchmark__compression__zstd encode.snap.new
@@ -1,0 +1,6 @@
+---
+source: puffin/benches/compression.rs
+assertion_line: 77
+expression: "report_compression(&test_stream, &encoded)"
+---
+"79073128bytes - ratio 3.16"


### PR DESCRIPTION
After noticing that by far the slowest dependency to build on my machine was zstd (see https://github.com/rerun-io/rerun/issues/1316), I set out in search for finding an alternative compression library that is pure Rust and has similar compression ratio & speed as zstd.

Not very successful so far! Seems the C written zstd is _a lot_ faster than everything tried here!

Measurements on my M1 Max so far:

```
zstd encode            27.214 ms
zstd decode            8.7848 ms

gzip (flate2) encode   34.933 ms
gzip (flate2) decode   20.368 ms

lzma (lzma-rs) encode  157.91 ms
lzma (lzma-rs) decode  369.42 ms

brotli encode          67.711 ms
brotli decode          36.595 ms
```

slightly tweaked for roughly similar compression ratios for the generated test data:
```
zstd:   3.16
gzip:   2.98
lzma:   2.16
brotli: 3.46
```


### Checklist

* [ ] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Describe your changes here

### Related Issues

List related issues here
