### PR TITLE
Switch default compression algorithm to lz4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,9 +2004,11 @@ dependencies = [
  "anyhow",
  "bincode",
  "byteorder",
+ "cfg-if",
  "criterion",
  "instant",
  "js-sys",
+ "lz4_flex",
  "once_cell",
  "parking_lot",
  "ruzstd",

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -18,7 +18,14 @@ all-features = true
 
 [features]
 default = []
-packing = ["anyhow", "bincode", "parking_lot", "serde", "zstd", "ruzstd"]
+packing = ["dep:anyhow", "dep:bincode", "dep:parking_lot", "lz4", "serde"]
+
+# Support lz4 compression. Fast, and lightweight dependency.
+# If both `lz4` and `zstd` are enabled, lz4 will be used for compression.
+lz4 = ["dep:lz4_flex"]
+
+# Support zstd compression. Slow and big dependency, but very good compression ratio.
+zstd = ["dep:zstd", "dep:ruzstd"]
 
 # Feature for enabling loading/saving data to a binary stream and/or file.
 serialization = ["packing"]
@@ -29,12 +36,14 @@ web = ["instant/wasm-bindgen", "dep:js-sys"]
 
 [dependencies]
 byteorder = { version = "1.0" }
+cfg-if = "1.0"
 instant = { version = "0.1" }
 once_cell = "1.0"
 
 # Optional:
 anyhow = { version = "1.0", optional = true }
 bincode = { version = "1.3", optional = true }
+lz4_flex = { version = "0.10", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 

--- a/puffin_http/Cargo.toml
+++ b/puffin_http/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam-channel = "0.5"
 log = "0.4"
 puffin = { version = "0.15.0", path = "../puffin", features = [
     "packing",
+    "lz4",
     "serialization",
 ] }
 

--- a/puffin_viewer/Cargo.toml
+++ b/puffin_viewer/Cargo.toml
@@ -20,6 +20,8 @@ puffin_egui = { version = "0.21.0", path = "../puffin_egui" }
 puffin = { version = "0.15.0", path = "../puffin", features = [
     "packing",
     "serialization",
+    "lz4",
+    "zstd",          # Support zstd in order to load old puffin files (before 0.16.0)
 ] }
 puffin_http = { version = "0.12.0", path = "../puffin_http" }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

[`lz4_flex`](https://github.com/PSeitz/lz4_flex) is a light-weight Rust-only dependency. 
It compiles and runs much faster than zstd, and it supports compression in wasm.

zstd compresses better, so you can still opt-in to it with the "zstd" feature.

For most `puffin` users the effect will be faster compilation time and less CPU usage (about a third of zstd). Benchmarks can be found here: https://github.com/EmbarkStudios/puffin/pull/130#issuecomment-1495549294

Users of `puffin` must update their `puffin_viewer`s, but the new `puffin_viewer` will still be able to open old puffin streams.
