### PR TITLE
Do not automerge Graphite stacked PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ pull_request_rules:
       - "#commented-reviews-by=0"
       - base=main
       - label!=work-in-progress
+      - label!=graphite
     actions:
       merge:
         method: squash


### PR DESCRIPTION
By for now checking a manual label on them and disabling Mergify on them.

So we can test using the built-in [Graphite](https://graphite.dev) support for "merge when ready" which understands stacks
