### PR TITLE
🫕 Remove `default_fonts` feature from `egui` in `puffin_egui`

### DIFF
--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -21,9 +21,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = { version = "0.22.0", default-features = false, features = [
-  "default_fonts",
-] }
+egui = { version = "0.22.0", default-features = false }
 indexmap = { version = "1.9.1", features = ["serde"] }
 instant = "0.1"
 natord = "1.0.9"


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Currently, `puffin_egui` depends on the `default_fonts` feature from `egui`. However, it does not actually depend on any of the default fonts (it does use `egui`'s font system). For users that want to provide `egui` with their own fonts this pulls in additional licenses.
