### PR TITLE
allow scopes to flush between each sample.

### DIFF
--- a/puffin/benches/benchmark.rs
+++ b/puffin/benches/benchmark.rs
@@ -2,24 +2,31 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     puffin::set_scopes_on(true);
-    puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
 
     c.bench_function("profile_function", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_function!();
         })
     });
     c.bench_function("profile_function_data", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_function!("my_mesh.obj");
         })
     });
     c.bench_function("profile_scope", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_scope!("my longish scope name");
         })
     });
     c.bench_function("profile_scope_data", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_scope!("my longish scope name", "my_mesh.obj");
         })
@@ -27,21 +34,29 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     puffin::set_scopes_on(false);
     c.bench_function("profile_function_off", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_function!();
         })
     });
     c.bench_function("profile_function_data_off", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_function!("my_mesh.obj");
         })
     });
     c.bench_function("profile_scope_off", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_scope!("my longish scope name");
         })
     });
     c.bench_function("profile_scope_data_off", |b| {
+        puffin::GlobalProfiler::lock().new_frame();
+        puffin::profile_scope!("keep one scope open so we don't profile sending scopes");
         b.iter(|| {
             puffin::profile_scope!("my longish scope name", "my_mesh.obj");
         })


### PR DESCRIPTION
Benchmarks run fine to the end, but then dies to memory kill at exit. The scope at the top seems to prevent flushing, so all data is kept in memory until we exit. By only delaying flushing until after each benchmark we can still hide it from measurement (assuming `bench_function` isn't measured) but prevent memory growth between benches. Adding the new_frame just for good measure as it allows dropping the data progressively too.