### PR TITLE
Don't adjust alpha of filtered out flamegraph scopes

### DIFF
--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -644,7 +644,8 @@ fn paint_record(
             // keep full opacity
             min_width *= 2.0; // make it more visible even when thin
         } else {
-            rect_color = rect_color.multiply(0.075); // fade to highlight others
+            // fade to highlight others
+            rect_color = lerp(Rgba::BLACK..=rect_color, 0.075);
         }
     }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Don't adjust alpha of filtered out flamegraph scopes.
Instead just fade the color.
Lowering the alpha results in accumulated colors with small scopes, which makes it look like scopes aren't filtered out.

Before: 
![image](https://github.com/EmbarkStudios/puffin/assets/1059884/dc8b1f12-19d3-43f4-9043-b99610c2ca77)

After: 
![image](https://github.com/EmbarkStudios/puffin/assets/1059884/cf4cf6bb-7c03-4a12-a449-d70848b6019c)
