### PR TITLE
Remove `instant` dependency when not building for web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - run: cargo fetch
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
+      - name: cargo clippy wasm32-unknown-unknown WITHOUT web feature
+        run: cargo clippy -p puffin --target wasm32-unknown-unknown --no-default-features -- -D warnings
       - name: cargo clippy wasm32
         run: cargo clippy -p puffin_viewer --target wasm32-unknown-unknown --all-features --lib
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04-16core
     env:
       # there is no published release for v0.7 yet, build from git revision
-      CARGO_VET_REVISION: 088586c
+      CARGO_VET_REVISION: 8c8b6d7a5237544c613de616a031586587f49a42
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,13 +1737,13 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "criterion",
- "instant",
  "js-sys",
  "lz4_flex",
  "once_cell",
  "parking_lot",
  "ruzstd",
  "serde",
+ "web-time",
  "zstd",
 ]
 
@@ -1754,13 +1754,13 @@ dependencies = [
  "eframe",
  "egui",
  "indexmap",
- "instant",
  "natord",
  "once_cell",
  "puffin",
  "serde",
  "time",
  "vec1",
+ "web-time",
 ]
 
 [[package]]
@@ -2543,6 +2543,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19353897b48e2c4d849a2d73cb0aeb16dc2be4e00c565abfc11eb65a806e47de"
+dependencies = [
+ "js-sys",
+ "once_cell",
  "wasm-bindgen",
 ]
 

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -31,7 +31,7 @@ zstd = ["dep:zstd", "dep:ruzstd"]
 serialization = ["packing"]
 
 # Enable this to be able to run puffin inside a browser when compiling to wasm
-web = ["instant/wasm-bindgen", "dep:js-sys"]
+web = ["dep:js-sys"]
 
 
 [dependencies]
@@ -53,7 +53,7 @@ zstd = { version = "0.12.3", optional = true } # native only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3", optional = true }
 ruzstd = { version = "0.4.0", optional = true } # works on wasm
-instant = { version = "0.1", optional = true }
+web-time = { version = "0.2", optional = true }
 
 
 [dev-dependencies]

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -31,7 +31,7 @@ zstd = ["dep:zstd", "dep:ruzstd"]
 serialization = ["packing"]
 
 # Enable this to be able to run puffin inside a browser when compiling to wasm
-web = ["dep:js-sys"]
+web = ["dep:js-sys", "dep:web-time"]
 
 
 [dependencies]

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -37,7 +37,6 @@ web = ["instant/wasm-bindgen", "dep:js-sys"]
 [dependencies]
 byteorder = { version = "1.0" }
 cfg-if = "1.0"
-instant = { version = "0.1" }
 once_cell = "1.0"
 
 # Optional:
@@ -54,6 +53,7 @@ zstd = { version = "0.12.3", optional = true } # native only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3", optional = true }
 ruzstd = { version = "0.4.0", optional = true } # works on wasm
+instant = { version = "0.1", optional = true }
 
 
 [dev-dependencies]

--- a/puffin/src/frame_data.rs
+++ b/puffin/src/frame_data.rs
@@ -153,16 +153,20 @@ compile_error!(
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CompressionKind {
+    #[allow(dead_code)] // with some feature sets
     Uncompressed = 0,
 
     /// Very fast, and lightweight dependency
+    #[allow(dead_code)] // with some feature sets
     Lz4 = 1,
 
     /// Big dependency, slow compression, but compresses better than lz4
+    #[allow(dead_code)] // with some feature sets
     Zstd = 2,
 }
 
 impl CompressionKind {
+    #[cfg(feature = "serialization")]
     fn from_u8(value: u8) -> anyhow::Result<Self> {
         match value {
             0 => Ok(Self::Uncompressed),

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -553,10 +553,10 @@ pub fn now_ns() -> NanoSecond {
 
     // This can maybe be optimized
 
-    #[cfg(feature = "web")]
-    use instant::Instant;
     #[cfg(not(feature = "web"))]
     use std::time::Instant;
+    #[cfg(feature = "web")]
+    use web_time::Instant;
 
     use once_cell::sync::Lazy;
 

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -553,9 +553,9 @@ pub fn now_ns() -> NanoSecond {
 
     // This can maybe be optimized
 
-    #[cfg(not(feature = "web"))]
+    #[cfg(not(target_arch = "wasm32"))]
     use std::time::Instant;
-    #[cfg(feature = "web")]
+    #[cfg(target_arch = "wasm32")]
     use web_time::Instant;
 
     use once_cell::sync::Lazy;

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -552,7 +552,12 @@ pub fn now_ns() -> NanoSecond {
     }
 
     // This can maybe be optimized
+
+    #[cfg(feature = "web")]
     use instant::Instant;
+    #[cfg(not(feature = "web"))]
+    use std::time::Instant;
+
     use once_cell::sync::Lazy;
 
     static START_TIME: Lazy<(NanoSecond, Instant)> =

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -23,7 +23,6 @@ include = [
 [dependencies]
 egui = { version = "0.22.0", default-features = false }
 indexmap = { version = "1.9.1", features = ["serde"] }
-instant = "0.1"
 natord = "1.0.9"
 once_cell = "1.7"
 puffin = { version = "0.16.0", path = "../puffin", features = ["packing"] }
@@ -33,6 +32,7 @@ time = { version = "0.3.17", default-features = false, features = [
   "macros",
 ] }
 vec1 = "1.8"
+web-time = "0.2"
 
 [dev-dependencies]
 eframe = { version = "0.22.0", default-features = false, features = [

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -346,7 +346,7 @@ pub struct ProfilerUi {
 
     /// When did we last run a pass to pack all the frames?
     #[cfg_attr(feature = "serde", serde(skip))]
-    last_pack_pass: Option<instant::Instant>,
+    last_pack_pass: Option<web_time::Instant>,
 }
 
 impl Default for ProfilerUi {
@@ -433,16 +433,16 @@ impl ProfilerUi {
         }
         let last_pack_pass = self
             .last_pack_pass
-            .get_or_insert_with(instant::Instant::now);
+            .get_or_insert_with(web_time::Instant::now);
         let time_since_last_pack = last_pack_pass.elapsed();
-        if time_since_last_pack > instant::Duration::from_secs(1) {
+        if time_since_last_pack > web_time::Duration::from_secs(1) {
             puffin::profile_scope!("pack_pass");
             for frame in self.all_known_frames(frame_view) {
                 if !self.is_selected(frame_view, frame.frame_index()) {
                     frame.pack();
                 }
             }
-            self.last_pack_pass = Some(instant::Instant::now());
+            self.last_pack_pass = Some(web_time::Instant::now());
         }
     }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.7"
+version = "0.8"
 
 [imports.embark]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
@@ -69,10 +69,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.accesskit]]
 version = "0.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.adler]]
-version = "1.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ahash]]
@@ -203,10 +199,6 @@ criteria = "safe-to-deploy"
 version = "2.3.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.fdeflate]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.gdk-pixbuf-sys]]
 version = "0.15.10"
 criteria = "safe-to-deploy"
@@ -287,10 +279,6 @@ criteria = "safe-to-deploy"
 version = "0.1.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.io-lifetimes]]
-version = "1.0.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.jni-sys]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
@@ -325,10 +313,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]
 version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.mio]]
-version = "0.8.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.ndk]]
@@ -475,10 +459,6 @@ criteria = "safe-to-deploy"
 version = "0.3.22"
 criteria = "safe-to-deploy"
 
-[[exemptions.time-core]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.time-macros]]
 version = "0.2.9"
 criteria = "safe-to-deploy"
@@ -501,10 +481,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]
 version = "1.6.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.unicode-bidi]]
-version = "0.3.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.url]]
@@ -539,6 +515,10 @@ criteria = "safe-to-deploy"
 version = "0.30.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.web-time]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.webbrowser]]
 version = "0.8.10"
 criteria = "safe-to-deploy"
@@ -560,7 +540,7 @@ version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-targets]]
-version = "0.42.1"
+version = "0.42.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-targets]]
@@ -568,7 +548,7 @@ version = "0.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_aarch64_gnullvm]]
-version = "0.42.0"
+version = "0.42.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_aarch64_gnullvm]]
@@ -576,7 +556,7 @@ version = "0.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_gnullvm]]
-version = "0.42.0"
+version = "0.42.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_gnullvm]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -520,6 +520,12 @@ criteria = "safe-to-deploy"
 violation = "<0.20.0"
 notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
 
+[[audits.embark.audits.fdeflate]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = "No unsafe usage or ambient capabilities"
+
 [[audits.embark.audits.idna]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -842,6 +848,16 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.1.3 -> 1.2.0"
 
+[[audits.firefox.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.firefox.audits.unicode-bidi]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.3.8 -> 0.3.13"
+
 [[audits.google.audits.anyhow]]
 who = "ChromeOS"
 criteria = "safe-to-deploy"
@@ -1004,6 +1020,18 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.io-lifetimes]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.10"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.io-lifetimes]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.10 -> 1.0.11"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.itertools]]
 who = "ChromeOS"
 criteria = "safe-to-deploy"
@@ -1032,6 +1060,12 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.2 -> 0.7.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.mio]]
+who = "Vovo Yang <vovoy@google.com>"
+criteria = "safe-to-deploy"
+version = "0.8.8"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.num_threads]]
@@ -1159,6 +1193,12 @@ user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2024-03-10"
 
+[[audits.wasmtime.audits.adler]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "This is a small crate which forbids unsafe code and is a straightforward implementation of the adler hashing algorithm."
+
 [[audits.wasmtime.audits.anes]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1224,6 +1264,15 @@ without `unsafe`. Skimming the crate everything looks reasonable and what one
 would expect from idiomatic safe collections in Rust.
 """
 
+[[audits.wasmtime.audits.unicode-bidi]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.3.8"
+notes = """
+This crate has no unsafe code and does not use `std::*`. Skimming the crate it
+does not attempt to out of the bounds of what it's already supposed to be doing.
+"""
+
 [[audits.wasmtime.audits.unicode-ident]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1265,6 +1314,12 @@ delta = "1.3.0 -> 1.3.1"
 notes = "Bumps MSRV to 1.60."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.time-core]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.tinyvec_macros]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -1284,44 +1339,4 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.5.1 -> 0.6.1"
 notes = "Fixes a bug in parsing negative minutes in datetime string offsets."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.windows-targets]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.42.1 -> 0.42.2"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.windows_aarch64_gnullvm]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "0.42.0 -> 0.42.1"
-notes = """
-This is a Windows API bindings library maintained by Microsoft themselves.
-Changes are to a bundled binary library; it looks like these were accidentally left out of 0.42.0.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.windows_aarch64_gnullvm]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.42.1 -> 0.42.2"
-notes = "This is an opaque Windows API bindings library maintained by Microsoft."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.windows_x86_64_gnullvm]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "0.42.0 -> 0.42.1"
-notes = """
-This is a Windows API bindings library maintained by Microsoft themselves.
-Changes are to a bundled binary library; it looks like these were accidentally left out of 0.42.0.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.windows_x86_64_gnullvm]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.42.1 -> 0.42.2"
-notes = "This is an opaque Windows API bindings library maintained by Microsoft."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"


### PR DESCRIPTION
This dependency was introduced originally in #112.

It is a platform abstraction, but it is a tiny one and it is not harder to just use the std type which avoids always pulling in `instant` including for `wasm32-unknown-unknown` when not building for the web where it has no purpose at all.

Want to have as few dependencies as possible on core low level crates like `puffin` that almost all of our code depends on.
