### PR TITLE
Faster and better location data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- [PR#165](https://github.com/EmbarkStudios/puffin/issues/165) Faster profiling, add line numbers, better paths, and better function names
+
 ## [0.17.0] - 2023-09-28
 
 - [PR#140](https://github.com/EmbarkStudios/puffin/issues/140) Remove imgui support for
@@ -28,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.2] - 2023-01-30
 
-- [PR#123](https://github.com/EmbarkStudios/puffin/pull/123) Fix `puffin` build for non-web wasm enviroments. 
+- [PR#123](https://github.com/EmbarkStudios/puffin/pull/123) Fix `puffin` build for non-web wasm enviroments.
 
 ## [0.14.1] - 2022-12-13
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ fn my_function() {
 }
 ```
 
-The Puffin macros write data to a thread-local data stream. When the outermost scope of a thread is closed, the data stream is sent to a global profiler collector. The scopes are pretty light-weight, costing around 60 ns on an M1 MacBook PRO.
+The Puffin macros write data to a thread-local data stream. When the outermost scope of a thread is closed, the data stream is sent to a global profiler collector. The scopes are pretty light-weight, costing around 60 ns on an M1 MacBook Pro.
 
-You have to turn on the profiler before it captures any data with a call to `puffin::set_scopes_on(true);`. When the profiler is off the profiler scope macros only has an overhead of 1 ns on an M1 MacBook PRO (plus some stack space).
+You have to turn on the profiler before it captures any data with a call to `puffin::set_scopes_on(true);`. When the profiler is off the profiler scope macros only has an overhead of 1 ns on an M1 MacBook Pro (plus some stack space).
 
 Once per frame you need to call `puffin::GlobalProfiler::lock().new_frame();`.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ fn my_function() {
 }
 ```
 
-The Puffin macros write data to a thread-local data stream. When the outermost scope of a thread is closed, the data stream is sent to a global profiler collector. The scopes are pretty light-weight, costing around 100-200 nanoseconds.
+The Puffin macros write data to a thread-local data stream. When the outermost scope of a thread is closed, the data stream is sent to a global profiler collector. The scopes are pretty light-weight, costing around 60 ns on an M1 MacBook PRO.
 
-You have to turn on the profiler before it captures any data with a call to `puffin::set_scopes_on(true);`. When the profiler is off the profiler scope macros only has an overhead of 1-2 ns (and some stack space);
+You have to turn on the profiler before it captures any data with a call to `puffin::set_scopes_on(true);`. When the profiler is off the profiler scope macros only has an overhead of 1 ns on an M1 MacBook PRO (plus some stack space).
 
 Once per frame you need to call `puffin::GlobalProfiler::lock().new_frame();`.
 

--- a/puffin/src/data.rs
+++ b/puffin/src/data.rs
@@ -4,18 +4,22 @@
 //!
 //! Each scope start consists of:
 //!
+//! ```ignore
 //!    '('          byte       Sentinel
 //!    time_ns      i64        Time stamp of when scope started
 //!    id           str        Scope name. Human readable, e.g. a function name. Never the empty string.
 //!    location     str        File name or similar. Could be the empty string.
 //!    data         str        Resource that is being processed, e.g. name of image being loaded. Could be the empty string.
 //!    scope_size   u64        Number of bytes of child scope
+//! ```
 //!
 //! This is followed by `scope_size` number of bytes of data
 //! containing any child scopes. The scope is then closed by:
 //!
+//! ```ignore
 //!    ')'          byte       Sentinel
 //!    time_ns      i64        Time stamp of when scope finished
+//! ```
 //!
 //! Integers are encoded in little endian.
 //! Strings are encoded as a single u8 length + that many bytes of UTF8.

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -628,7 +628,7 @@ macro_rules! current_function_name {
 }
 
 #[doc(hidden)]
-#[inline]
+#[inline(never)]
 pub fn clean_function_name(name: &str) -> String {
     // "foo::bar::baz" -> "baz"
     fn last_part(name: &str) -> &str {

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -701,7 +701,7 @@ macro_rules! current_file_name {
 ///
 /// We want to keep it short for two reasons: readability, and bandwidth
 #[doc(hidden)]
-#[inline]
+#[inline(never)]
 pub fn short_file_name(path: &'static str) -> String {
     let path = path.replace('\\', "/"); // Handle Windows
     let components: Vec<&str> = path.split('/').collect();

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -727,7 +727,7 @@ macro_rules! profile_function {
             let (function_name, location) = unsafe {
                 _INITITIALIZED.call_once(|| {
                     _FUNCTION_NAME = $crate::current_function_name!();
-                    _LOCATION = $crate::current_file_name!();
+                    _LOCATION = format!("{}:{}", $crate::current_file_name!(), line!()).leak();
                 });
                 (_FUNCTION_NAME, _LOCATION)
             };
@@ -768,7 +768,7 @@ macro_rules! profile_scope {
             // SAFETY: accessing the statics is safe because it is done in cojunction with `std::sync::Once``
             let location = unsafe {
                 _INITITIALIZED.call_once(|| {
-                    _LOCATION = $crate::current_file_name!();
+                    _LOCATION = format!("{}:{}", $crate::current_file_name!(), line!()).leak();
                 });
                 _LOCATION
             };

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -629,7 +629,7 @@ macro_rules! current_function_name {
 
 #[doc(hidden)]
 #[inline(never)]
-pub fn clean_function_name(name: &str) -> String {
+pub fn clean_function_name(name: &'static str) -> String {
     // "foo::bar::baz" -> "baz"
     fn last_part(name: &str) -> &str {
         if let Some(colon) = name.rfind("::") {

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -702,7 +702,7 @@ macro_rules! current_file_name {
 /// We want to keep it short for two reasons: readability, and bandwidth
 #[doc(hidden)]
 #[inline]
-pub fn short_file_name(path: &str) -> String {
+pub fn short_file_name(path: &'static str) -> String {
     let path = path.replace('\\', "/"); // Handle Windows
     let components: Vec<&str> = path.split('/').collect();
     if components.len() <= 2 {

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -258,7 +258,7 @@ pub fn ui(ui: &mut egui::Ui, options: &mut Options, frames: &SelectedFrames) {
                         let entry = options
                             .flamegraph_threads
                             .entry(f.name.clone())
-                            .or_insert_with(ThreadVisualizationSettings::default);
+                            .or_default();
                         ui.checkbox(&mut entry.flamegraph_show, f.name.clone());
                     }
                 });
@@ -344,7 +344,7 @@ fn ui_canvas(
         let thread_visualization = options
             .flamegraph_threads
             .entry(thread_info.name.clone())
-            .or_insert_with(ThreadVisualizationSettings::default);
+            .or_default();
 
         if !thread_visualization.flamegraph_show {
             continue;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Summary
Before:
<img width="409" alt="puffin-before" src="https://github.com/EmbarkStudios/puffin/assets/1148717/e5722ab6-3865-4f5d-a953-672e4c1e5c86">

After:
<img width="665" alt="puffin-after" src="https://github.com/EmbarkStudios/puffin/assets/1148717/dc829830-d2cf-400d-b5d5-9f92a892ff60">


### Description of Changes

This PR:
* Improve the function names for `trait` calls
* Adds crate name to the file path
* Adds line number to the location
* Optimize `profile_function`

On my M1 MacBook Pro, `profile_function` goes from 86ns->58ns, about 50% faster. `profile_scope` goes from 60ns to 58ns, which is within noise levels.

The optimization is done by caching the results of the location gathering functions. This also allows us to make them more expensive (since they are now only run once), and therefor more powerful.

So where puffin used to output the location `mod.rs`, it now outputs `cratename/…/modulename/mod.rs:124`.

I also improved the function name for when calling a trait method on a type. Previously you'd only see `TraitName>::function_name` but now you'll see `<ConreteTypeName as TraitName>::function_name`.

The downside is more data being sent, but I think the improves usefulness of the location is worth it!

This is _not_ a breaking change, so this can be released in a patch-release of `puffin`