### PR TITLE
Remove accidental `::{{closure}}` suffix from all `profile_function` scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- [PR#175](https://github.com/EmbarkStudios/puffin/issues/175) Remove accidental `::{{closure}}` suffix from all `profile_function` scopes.
+
 ## [0.18.0] - 2023-11-21
-## [0.17.1] - 2023-11-20
 
 - [PR#165](https://github.com/EmbarkStudios/puffin/issues/165) Faster profiling, add line numbers, better paths, and better function names
+
+## [0.17.1] - 2023-11-20 - YANKED
+
+- Accidentally introduced a breaking change in [PR#165](https://github.com/EmbarkStudios/puffin/issues/165)
 
 ## [0.17.0] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
-- [PR#175](https://github.com/EmbarkStudios/puffin/issues/175) Remove accidental `::{{closure}}` suffix from all `profile_function` scopes.
+- [PR#175](https://github.com/EmbarkStudios/puffin/pull/175) Remove accidental `::{{closure}}` suffix from all `profile_function` scopes.
 
 ## [0.18.0] - 2023-11-21
 
-- [PR#165](https://github.com/EmbarkStudios/puffin/issues/165) Faster profiling, add line numbers, better paths, and better function names
+- [PR#165](https://github.com/EmbarkStudios/puffin/pull/165) Faster profiling, add line numbers, better paths, and better function names
 
 ## [0.17.1] - 2023-11-20 - YANKED
 
-- Accidentally introduced a breaking change in [PR#165](https://github.com/EmbarkStudios/puffin/issues/165)
+- Accidentally introduced a breaking change in [PR#165](https://github.com/EmbarkStudios/puffin/pull/165)
 
 ## [0.17.0] - 2023-09-28
 
-- [PR#140](https://github.com/EmbarkStudios/puffin/issues/140) Remove imgui support for
+- [PR#140](https://github.com/EmbarkStudios/puffin/pull/140) Remove imgui support for
 - [PR#158](https://github.com/EmbarkStudios/puffin/pull/158) Remove file I/O from
-- [PR#157](https://github.com/EmbarkStudios/puffin/issues/157) Remove `instant` dependency when not building for web
+- [PR#157](https://github.com/EmbarkStudios/puffin/pull/157) Remove `instant` dependency when not building for web
 
 ## [0.16.0] - 2023-05-24
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

In https://github.com/EmbarkStudios/puffin/issues/165 I inadvertently added a `::{{closure}}` suffix to the name of all profile scopes created with `profile_function!`, somehow not noticing it until now 🤦
