### PR TITLE
Measure time after serialization.

### DIFF
--- a/puffin/src/data.rs
+++ b/puffin/src/data.rs
@@ -110,7 +110,13 @@ impl Stream {
     /// Marks the beginning of the scope.
     /// Returns position where to write scope size once the scope is closed
     #[inline]
-    pub fn begin_scope(&mut self, now_ns: &NsSource, scope_id: ScopeId, data: &str) -> (usize, NanoSecond) {
+    pub fn begin_scope(
+        &mut self,
+        now_ns: &NsSource,
+        offset_for_test: i64,
+        scope_id: ScopeId,
+        data: &str,
+    ) -> (usize, NanoSecond) {
         self.0.push(SCOPE_BEGIN);
 
         self.write_scope_id(scope_id);
@@ -126,8 +132,8 @@ impl Stream {
 
         // Do the timing last such that it doesn't include serialization
         let mut time_stamp_dest =
-        &mut self.0[time_stamp_offset..time_stamp_offset + size_of::<NanoSecond>()];
-        let start_ns = now_ns();
+            &mut self.0[time_stamp_offset..time_stamp_offset + size_of::<NanoSecond>()];
+        let start_ns = now_ns() + offset_for_test;
         time_stamp_dest
             .write_i64::<LE>(start_ns)
             .expect("can't fail");
@@ -488,8 +494,8 @@ impl<'s> Iterator for Reader<'s> {
 #[test]
 fn write_scope() {
     let mut stream: Stream = Stream::default();
-    let start = stream.begin_scope(100, ScopeId::new(1), "data");
-    stream.end_scope(start, 300);
+    let start = stream.begin_scope(&(now_ns as fn() -> i64), 100, ScopeId::new(1), "data");
+    stream.end_scope(start.0, 300);
 
     let scopes = Reader::from_start(&stream).read_top_scopes().unwrap();
     assert_eq!(scopes.len(), 1);
@@ -507,11 +513,11 @@ fn write_scope() {
 fn test_profile_data() {
     let stream = {
         let mut stream = Stream::default();
-
-        let t0 = stream.begin_scope(100, ScopeId::new(1), "data_top");
-        let m1 = stream.begin_scope(200, ScopeId::new(2), "data_middle_0");
+        let ptr = &(now_ns as fn() -> i64);
+        let (t0, _) = stream.begin_scope(ptr, 100, ScopeId::new(1), "data_top");
+        let (m1, _) = stream.begin_scope(ptr, 200, ScopeId::new(2), "data_middle_0");
         stream.end_scope(m1, 300);
-        let m1 = stream.begin_scope(300, ScopeId::new(3), "data_middle_1");
+        let (m1, _) = stream.begin_scope(ptr, 300, ScopeId::new(3), "data_middle_1");
         stream.end_scope(m1, 400);
         stream.end_scope(t0, 400);
         stream

--- a/puffin/src/merge.rs
+++ b/puffin/src/merge.rs
@@ -215,16 +215,18 @@ mod tests {
 
             for i in 0..2 {
                 let ns = 1000 * i;
-                let a = stream.begin_scope(ns + 100, ScopeId::new(1), "");
+                let ptr = &(now_ns as fn() -> i64);
+
+                let (a, _) = stream.begin_scope(ptr, 200, ScopeId::new(1), "");
                 stream.end_scope(a, ns + 200);
 
-                let b = stream.begin_scope(ns + 200, ScopeId::new(2), "");
+                let (b, _) = stream.begin_scope(ptr, ns + 200, ScopeId::new(2), "");
 
-                let ba = stream.begin_scope(ns + 400, ScopeId::new(3), "");
+                let (ba, _) = stream.begin_scope(ptr, ns + 400, ScopeId::new(3), "");
                 stream.end_scope(ba, ns + 600);
 
-                let bb = stream.begin_scope(ns + 600, ScopeId::new(4), "");
-                let bba = stream.begin_scope(ns + 600, ScopeId::new(5), "");
+                let (bb, _) = stream.begin_scope(ptr, ns + 600, ScopeId::new(4), "");
+                let (bba, _) = stream.begin_scope(ptr, ns + 600, ScopeId::new(5), "");
                 stream.end_scope(bba, ns + 700);
                 stream.end_scope(bb, ns + 800);
                 stream.end_scope(b, ns + 900);

--- a/puffin/src/thread_profiler.rs
+++ b/puffin/src/thread_profiler.rs
@@ -106,7 +106,7 @@ impl ThreadProfiler {
         let (offset, start_ns) =
             self.stream_info
                 .stream
-                .begin_scope(&self.now_ns, scope_id, data);
+                .begin_scope(&self.now_ns, 0, scope_id, data);
 
         self.stream_info.range_ns.0 = self.stream_info.range_ns.0.min(start_ns);
         self.start_time_ns = Some(self.start_time_ns.unwrap_or(start_ns));

--- a/puffin/src/thread_profiler.rs
+++ b/puffin/src/thread_profiler.rs
@@ -101,13 +101,17 @@ impl ThreadProfiler {
     /// Returns position where to write scope size once the scope is closed.
     #[must_use]
     pub fn begin_scope(&mut self, scope_id: ScopeId, data: &str) -> usize {
-        let now_ns = (self.now_ns)();
-        self.start_time_ns = Some(self.start_time_ns.unwrap_or(now_ns));
-
         self.depth += 1;
 
-        self.stream_info.range_ns.0 = self.stream_info.range_ns.0.min(now_ns);
-        self.stream_info.stream.begin_scope(now_ns, scope_id, data)
+        let (offset, start_ns) =
+            self.stream_info
+                .stream
+                .begin_scope(&self.now_ns, scope_id, data);
+
+        self.stream_info.range_ns.0 = self.stream_info.range_ns.0.min(start_ns);
+        self.start_time_ns = Some(self.start_time_ns.unwrap_or(start_ns));
+
+        offset
     }
 
     /// Marks the end of the scope.


### PR DESCRIPTION
### Description of Changes

Take time after serializing data to stream to be more accurate. 


Api of begin_scope is a bit weird now for tests. Could potentially split up in different functions that are used by test/normal code.