### PR TITLE
Clean function and shorten file names only in macros

### DIFF
--- a/puffin/src/global_profiler.rs
+++ b/puffin/src/global_profiler.rs
@@ -135,11 +135,8 @@ impl GlobalProfiler {
     ) {
         if !scope_details.is_empty() {
             // Here we can run slightly heavy logic as its only ran once for each scope.
-            self.new_scopes.extend(
-                scope_details
-                    .iter()
-                    .map(|x| Arc::new(x.clone().into_readable().clone())),
-            );
+            self.new_scopes
+                .extend(scope_details.iter().map(|x| Arc::new(x.clone())));
         }
 
         self.current_frame

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -216,8 +216,8 @@ macro_rules! profile_function {
             let scope_id = SCOPE_ID.get_or_init(|| {
                 $crate::ThreadProfiler::call(|tp| {
                     let id = tp.register_function_scope(
-                        $crate::current_function_name!(),
-                        file!(),
+                        $crate::clean_function_name($crate::current_function_name!()),
+                        $crate::short_file_name(file!()),
                         line!(),
                     );
                     id
@@ -254,8 +254,8 @@ macro_rules! profile_scope {
                 $crate::ThreadProfiler::call(|tp| {
                     let id = tp.register_named_scope(
                         $name,
-                        $crate::current_function_name!(),
-                        file!(),
+                        $crate::clean_function_name($crate::current_function_name!()),
+                        $crate::short_file_name(file!()),
                         line!(),
                     );
                     id

--- a/puffin/src/scope_details.rs
+++ b/puffin/src/scope_details.rs
@@ -1,4 +1,4 @@
-use crate::{clean_function_name, short_file_name, ScopeId};
+use crate::ScopeId;
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 #[derive(Default, Clone)]
@@ -183,21 +183,6 @@ impl ScopeDetails {
             format!("{}:{}", self.file_path, self.line_nr)
         } else {
             format!("{}", self.file_path)
-        }
-    }
-
-    /// Turns the scope details into a more readable version:
-    ///
-    /// * Consistent / shortened file path across platforms
-    /// * Consistent / shortened function name
-    #[inline]
-    pub(crate) fn into_readable(self) -> Self {
-        Self {
-            scope_id: self.scope_id,
-            scope_name: self.scope_name,
-            function_name: clean_function_name(&self.function_name).into(),
-            file_path: short_file_name(&self.file_path).into(),
-            line_nr: self.line_nr,
         }
     }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Clean the function names and shorten the file paths from the `::{{closure}}::{{closure}}::f` suffix directly in the `profile_function!` and `profile_scope!` macros when registering the scope (in the `OnceLock::get_or_init` closure).

Motivation: Avoid making assumptions about the format of the function names and file paths, for those who are using puffin directly as a general profiling tool (not going through `profile_function!` and `profile_scope!` macros).