### PR TITLE
Expose a public `shorten_rust_function_name` function

### DIFF
--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -42,7 +42,7 @@ pub use merge::{merge_scopes_for_thread, MergeScope};
 pub use profile_view::{select_slowest, FrameView, GlobalFrameView};
 pub use scope_details::{ScopeCollection, ScopeDetails, ScopeType};
 pub use thread_profiler::{ThreadInfo, ThreadProfiler};
-pub use utils::{clean_function_name, short_file_name, type_name_of};
+pub use utils::{clean_function_name, short_file_name, shorten_rust_function_name, type_name_of};
 
 static MACROS_ON: AtomicBool = AtomicBool::new(false);
 

--- a/puffin/src/utils.rs
+++ b/puffin/src/utils.rs
@@ -10,7 +10,22 @@ pub fn clean_function_name(name: &str) -> String {
         // Probably the user registered a user scope name.
         return name.to_owned();
     };
+    shorten_rust_function_name(name)
+}
 
+/// Shorten a rust function name by removing the leading parts of module paths.
+///
+/// While the puffin profiling macros takes care of this internally, this function can be
+/// useful for those registering custom scopes for rust functions.
+///
+/// # Example
+/// ```
+/// use puffin::shorten_rust_function_name;
+///
+/// assert_eq!(shorten_rust_function_name("foo::bar::baz::function_name"), "baz::function_name");
+/// assert_eq!(shorten_rust_function_name("<some::ConcreteType as some::Trait>::function_name"), "<ConcreteType as Trait>::function_name");
+/// ```
+pub fn shorten_rust_function_name(name: &str) -> String {
     // "foo::bar::baz" -> "baz"
     fn last_part(name: &str) -> &str {
         if let Some(colon) = name.rfind("::") {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Extract the parts that might be generally usable for rust function name shortening from `clean_function_name` (everything except the handling of the `::{{closure}}::{{closure}}::f` suffix) into a public function.

Useful for those handling custom scopes from rust functions.


### Related Issues

[#182: Clean function and shorten file names only in macros](https://github.com/EmbarkStudios/puffin/pull/182).
