### PR TITLE
🪂 Disable `drag_to_scroll` on frame selection `ScrollArea`

### DIFF
--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the egui crate will be documented in this file.
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+- [PR#207](https://github.com/EmbarkStudios/puffin/pull/207) Fixed frame selection input handling
+
 ## [0.27.0] - 2024-04-06
 - [PR#201](https://github.com/EmbarkStudios/puffin/pull/201) Update to egui `0.27`
 

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -565,6 +565,7 @@ impl ProfilerUi {
             Frame::dark_canvas(ui.style()).show(ui, |ui| {
                 egui::ScrollArea::horizontal()
                     .stick_to_right(true)
+                    .drag_to_scroll(false)
                     .show(ui, |ui| {
                         let slowest_visible = self.show_frame_list(
                             ui,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
In the version `0.27` release of `egui`, the interaction handling was changed. This caused the frame selection in the frame graph to be unselectable. By disabling the `drag_to_scroll` on the related `ScrollArea` this issue is solved.

The latest frame selection does not suffer from this, as it does not use a `ScrollArea`.

### Related Issues
- Fixes #205