### PR TITLE
Revert update to egui 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,9 +668,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.27.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb152797942f72b84496eb2ebeff0060240e0bf55096c4525ffa22dd54722d86"
+checksum = "9c912193fa5698d4fbc857b831fb96b42215dcf565e06012993a65901299a21f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.27.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcc8e06df6f0a6cf09a3247ff7e85fdfffc28dda4fe5561e05314bf7618a918"
+checksum = "2230537c7ee42c4c329461bad5933e91a8f938a9314645961e12e57080478731"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1b8cc14b0b260aa6bd124ef12c8a94f57ffe8e40aa970f3db710c21bb945f3"
+checksum = "abecd396ede556116fceaa0098a1c9278ef526119c5097311eac4bcf57484c52"
 dependencies = [
  "accesskit",
  "ahash",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3733435d6788c760bb98ce4cb1b8b7a2d953a3a7b421656ba8b3e014019be3d0"
+checksum = "d85f8f89d6a937535e164a5bd6e31719fd7db01bc188d7b59425414b160a2ee1"
 dependencies = [
  "arboard",
  "egui",
@@ -746,15 +746,16 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f933e9e64c4d074c78ce71785a5778f648453c2b2a3efd28eea189dac3f19c28"
+checksum = "e3b8d8d33da3d2ae4db39b30ddcbc5f31e9b0d74e65dc028cf711e94b68ec4d6"
 dependencies = [
  "bytemuck",
  "egui",
  "glow",
  "log",
- "memoffset 0.9.1",
+ "memoffset",
+ "raw-window-handle 0.5.2",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -767,9 +768,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.27.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555a7cbfcc52c81eb5f8f898190c840fa1c435f67f30b7ef77ce7cf6b7dcd987"
+checksum = "2386663fafbd043f2cd14f0ded4702deb9348fb7e7bacba9c9087a31b17487f1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -801,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd63c37156e949bda80f7e39cc11508bc34840aecf52180567e67cdb2bf1a5fe"
+checksum = "36ac8c9ca960f0263856a7fbc90d7ad41280e8865a7cd3c64d3daec016bd7115"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1366,15 +1367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mimalloc"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,7 +1431,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
 ]
 
 [[package]]

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = { version = "0.27.1", default-features = false }
+egui = { version = "0.26.1", default-features = false }
 indexmap = { version = "2.1.0", features = ["serde"] }
 natord = "1.0.9"
 once_cell = "1.7"
@@ -36,7 +36,7 @@ vec1 = "1.8"
 web-time = "0.2"
 
 [dev-dependencies]
-eframe = { version = "0.27.1", default-features = false, features = [
+eframe = { version = "0.26.0", default-features = false, features = [
   "default_fonts",
   "glow",
 ] }

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -475,8 +475,8 @@ impl ProfilerUi {
 
         ui.horizontal(|ui| {
             let play_pause_button_size = Vec2::splat(24.0);
-            let space_pressed = ui.input(|i| i.key_pressed(egui::Key::Space))
-                && ui.memory(|m| m.focused().is_none());
+            let space_pressed =
+                ui.input(|i| i.key_pressed(egui::Key::Space)) && ui.memory(|m| m.focus().is_none());
 
             if self.paused.is_some() {
                 if ui

--- a/puffin_viewer/Cargo.toml
+++ b/puffin_viewer/Cargo.toml
@@ -28,7 +28,7 @@ puffin = { version = "0.19.0", path = "../puffin", features = [
 puffin_http = { version = "0.16.0", path = "../puffin_http" }
 
 argh = "0.1"
-eframe = { version = "0.27.1", default-features = false, features = [
+eframe = { version = "0.26.0", default-features = false, features = [
     "default_fonts",
     "glow",
     "persistence",


### PR DESCRIPTION
* Reverts https://github.com/EmbarkStudios/puffin/pull/201
* Closes https://github.com/EmbarkStudios/puffin/issues/205

The update to egui 0.27 broke scrolling and selection of scopes in the flamegraph.

I'll revert it, and then we don't merge things without testing them next time.