### PR TITLE
Alllow using custom GlobalProfiler instance with puffin_http::Server

### DIFF
--- a/puffin/src/global_profiler.rs
+++ b/puffin/src/global_profiler.rs
@@ -127,7 +127,7 @@ impl GlobalProfiler {
     }
 
     /// Reports some profiling data. Called from [`ThreadProfiler`].
-    pub(crate) fn report(
+    pub fn report(
         &mut self,
         info: ThreadInfo,
         scope_details: &[ScopeDetails],

--- a/puffin_http/Cargo.toml
+++ b/puffin_http/Cargo.toml
@@ -25,3 +25,5 @@ puffin = { version = "0.19.0", path = "../puffin", features = [
 
 [dev-dependencies]
 simple_logger = "4.2"
+paste = "1.0.15"
+once_cell = "1.19.0"

--- a/puffin_http/src/server.rs
+++ b/puffin_http/src/server.rs
@@ -21,7 +21,7 @@ pub struct Server {
     sink_id: puffin::FrameSinkId,
     join_handle: Option<std::thread::JoinHandle<()>>,
     num_clients: Arc<AtomicUsize>,
-    sink_remove: Option<Box<dyn FnOnce(puffin::FrameSinkId) -> () + Send + 'static>>,
+    sink_remove: fn(puffin::FrameSinkId) -> (),
 }
 
 impl Server {
@@ -222,8 +222,8 @@ impl Server {
     /// ```
     pub fn new_custom(
         bind_addr: &str,
-        sink_install: impl FnOnce(puffin::FrameSink) -> puffin::FrameSinkId,
-        sink_remove: impl FnOnce(puffin::FrameSinkId) -> () + Send + 'static,
+        sink_install: fn (puffin::FrameSink) -> puffin::FrameSinkId,
+        sink_remove: fn (puffin::FrameSinkId) -> (),
     ) -> anyhow::Result<Self> {
         let tcp_listener = TcpListener::bind(bind_addr).context("binding server TCP socket")?;
         tcp_listener
@@ -273,7 +273,7 @@ impl Server {
             sink_id,
             join_handle: Some(join_handle),
             num_clients,
-            sink_remove: Some(Box::new(sink_remove)),
+            sink_remove,
         })
     }
 
@@ -286,10 +286,7 @@ impl Server {
 impl Drop for Server {
     fn drop(&mut self) {
         // Remove ourselves from the profiler
-        match self.sink_remove.take() {
-            None => log::warn!("puffin server could not remove sink: was `None`"),
-            Some(sink_remove) => sink_remove(self.sink_id),
-        };
+        (self.sink_remove)(self.sink_id);
 
         // Take care to send everything before we shut down:
         if let Some(join_handle) = self.join_handle.take() {


### PR DESCRIPTION
# Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

# Changes

Allow `puffin_http::Server` to use a custom `puffin::GlobalProfiler` instance.

- Add a new constructor function `Server::new_custom()`
- It takes in two function pointers to call when adding/removing the `Server` as a `Sink`.
- These can be changed to add to a `GlobalProfiler` instance that isn't the default instance returned by `GlobalProfiler::lock()`
- Existing `Server::new()` now simply wraps this new function around the default `GlobalProfiler::lock()` function, so behaviour is the same
- Add extensive documentation including working examples and a helpful macro

# Example Usage

Here's a video of me using it to profile my project [`rayna`](https://github.com/v0x0g/rayna).

On the left we have my app, with the **render** profiler running top right and the **ui** profiler running bottom right. Note that this is _one app process_, but it has two separate `puffin_http::Server` instances. Note how in the video these profilers are sending frames completely independently, but for the same process.

_Apologies for the compression, it doesn't seem to like my noisy images..._

https://github.com/EmbarkStudios/puffin/assets/153816778/f1ef7625-294b-4347-aad4-0062f0f1b3b7