### PR TITLE
🪂 Disable `drag_to_scroll` on frame selection `ScrollArea`

### DIFF
--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the egui crate will be documented in this file.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+- [PR#214](https://github.com/EmbarkStudios/puffin/pull/214) Fix frame selection input handling
 - [PR#218](https://github.com/EmbarkStudios/puffin/pull/218) Fix flamegraph click intersection
 
 ## [0.27.1] - 2024-06-16

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -565,6 +565,7 @@ impl ProfilerUi {
             Frame::dark_canvas(ui.style()).show(ui, |ui| {
                 egui::ScrollArea::horizontal()
                     .stick_to_right(true)
+                    .drag_to_scroll(false)
                     .show(ui, |ui| {
                         let slowest_visible = self.show_frame_list(
                             ui,


### PR DESCRIPTION
Redo of #207

### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
In the version `0.27` release of `egui`, the interaction handling was changed. This caused the scope selection in the flamegraph to be unselectable. By disabling the `drag_to_scroll` on the related `ScrollArea` this issue is solved.

The latest scope selection does not suffer from this, as it does not use a `ScrollArea`.

Note that this does not have any behavioral effect, but instead results in the same behavior of click/drag/scroll when on egui `0.26`!

### Related Issues
- Fixes #205

```[tasklist]
### Tested on
- [x] Windows
- [x] Linux
- [x] Mac
- [x] Android
```