### PR TITLE
Fix 'Viewer labeling scopes wrong when restarting app'

### DIFF
--- a/puffin_http/src/client.rs
+++ b/puffin_http/src/client.rs
@@ -51,6 +51,7 @@ impl Client {
                 while alive.load(SeqCst) {
                     match std::net::TcpStream::connect(&addr) {
                         Ok(mut stream) => {
+                            *frame_view.lock() = FrameView::default();
                             log::info!("Connected to {}", addr);
                             connected.store(true, SeqCst);
                             while alive.load(SeqCst) {

--- a/puffin_viewer/README.md
+++ b/puffin_viewer/README.md
@@ -11,4 +11,11 @@ cargo install puffin_viewer
 puffin_viewer --url 127.0.0.1:8585
 ```
 
+### On Linux
+
+On Linux gtk3 sources are required for file dialogs. You may install them on Ubuntu using the following command:
+```sh
+sudo apt install libgtk-3-dev
+```
+
 The puffin icon is based on [a photo by Richard Bartz](https://en.wikipedia.org/wiki/File:Papageitaucher_Fratercula_arctica.jpg).


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When connecting to a server, *always* reset the FrameView state, otherwise lingering ScopeDetails can cause scopes to be labeled wrong. See https://github.com/EmbarkStudios/puffin/issues/215 for details. 

Also add a note to viewer's readme that gtk3 sources need to be installed on Linux.

### Related Issues

Fixes https://github.com/EmbarkStudios/puffin/issues/215
