### PR TITLE
Ensure same intersection bounds are always used

### DIFF
--- a/puffin_egui/CHANGELOG.md
+++ b/puffin_egui/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the egui crate will be documented in this file.
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- [PR#218](https://github.com/EmbarkStudios/puffin/pull/218) Fix flamegraph click intersection
+
 ## [0.27.1] - 2024-06-16
 
 - [PR#211](https://github.com/EmbarkStudios/puffin/pull/211/) Fix broken flamegraph interaction with egui 0.27.1

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -689,7 +689,7 @@ impl ProfilerUi {
             };
 
             let frame_rect = Rect::from_min_max(
-                Pos2::new(x, rect.top()),
+                Pos2::new(x - 0.5 * frame_spacing, rect.top() + 0.5 * frame_spacing),
                 Pos2::new(x + frame_width, rect.bottom()),
             );
 
@@ -700,11 +700,9 @@ impl ProfilerUi {
                 let is_selected = self.is_selected(frame_view, frame.frame_index());
 
                 let is_hovered = if let Some(mouse_pos) = response.hover_pos() {
-                    response.hovered()
-                        && !response.dragged()
-                        && frame_rect
-                            .expand2(vec2(0.5 * frame_spacing, 0.0))
-                            .contains(mouse_pos)
+                    !response.dragged()
+                    && frame_rect
+                        .contains(mouse_pos)
                 } else {
                     false
                 };

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -689,9 +689,9 @@ impl ProfilerUi {
             };
 
             let frame_rect = Rect::from_min_max(
-                Pos2::new(x - 0.5 * frame_spacing, rect.top() + 0.5 * frame_spacing),
-                Pos2::new(x + frame_width, rect.bottom()),
-            );
+                Pos2::new(x, rect.top()),
+                Pos2::new(x + frame_width , rect.bottom()),
+            ).expand2(vec2(0.5 * frame_spacing, 0.0));
 
             if ui.clip_rect().intersects(frame_rect) {
                 let duration = frame.duration_ns();
@@ -742,14 +742,18 @@ impl ProfilerUi {
                     Rgba::from_rgb(0.6, 0.6, 0.4)
                 };
 
+                // Shrink the rect as the visual representation of the frame rect includes empty 
+                // space between each bar
+                let visual_rect = frame_rect.expand2(vec2(-0.5 * frame_spacing, 0.0));
+
                 // Transparent, full height:
-                let alpha = if is_selected || is_hovered { 0.6 } else { 0.25 };
-                painter.rect_filled(frame_rect, 0.0, color * alpha);
+                let alpha: f32 = if is_selected || is_hovered { 0.6 } else { 0.25 };
+                painter.rect_filled(visual_rect, 0.0, color * alpha);
 
                 // Opaque, height based on duration:
-                let mut short_rect = frame_rect;
+                let mut short_rect = visual_rect;
                 short_rect.min.y = lerp(
-                    frame_rect.bottom_up_range(),
+                    visual_rect.bottom_up_range(),
                     duration as f32 / slowest_frame,
                 );
                 painter.rect_filled(short_rect, 0.0, color);

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -690,8 +690,9 @@ impl ProfilerUi {
 
             let frame_rect = Rect::from_min_max(
                 Pos2::new(x, rect.top()),
-                Pos2::new(x + frame_width , rect.bottom()),
-            ).expand2(vec2(0.5 * frame_spacing, 0.0));
+                Pos2::new(x + frame_width, rect.bottom()),
+            )
+            .expand2(vec2(0.5 * frame_spacing, 0.0));
 
             if ui.clip_rect().intersects(frame_rect) {
                 let duration = frame.duration_ns();
@@ -700,9 +701,7 @@ impl ProfilerUi {
                 let is_selected = self.is_selected(frame_view, frame.frame_index());
 
                 let is_hovered = if let Some(mouse_pos) = response.hover_pos() {
-                    !response.dragged()
-                    && frame_rect
-                        .contains(mouse_pos)
+                    !response.dragged() && frame_rect.contains(mouse_pos)
                 } else {
                     false
                 };
@@ -742,7 +741,7 @@ impl ProfilerUi {
                     Rgba::from_rgb(0.6, 0.6, 0.4)
                 };
 
-                // Shrink the rect as the visual representation of the frame rect includes empty 
+                // Shrink the rect as the visual representation of the frame rect includes empty
                 // space between each bar
                 let visual_rect = frame_rect.expand2(vec2(-0.5 * frame_spacing, 0.0));
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This ensures the bounds for a `frame_rect` is always the same when checking for intersection in puffin_egui.

Also removed unnecessary call to `response.hovered()`. 

### Related Issues

Fixes #217
