### PR TITLE
Improve the `puffin_viewer` UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.rs.bk
 **/target_ra/
 **/target/
+/*.puffin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +764,27 @@ checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
  "serde",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1801,6 +1835,7 @@ version = "0.28.0"
 dependencies = [
  "eframe",
  "egui",
+ "egui_extras",
  "indexmap",
  "natord",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.76"
 
+
+[profile.dev.package."*"]
+# Optimize all dependencies even in debug builds (does not affect workspace packages):
+opt-level = 2
+
+
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"
 future_incompatible = "warn"

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -392,59 +392,7 @@ macro_rules! profile_scope_if {
 mod tests {
     use std::borrow::Cow;
 
-    use crate::{
-        clean_function_name, set_scopes_on, short_file_name, utils::USELESS_SCOPE_NAME_SUFFIX,
-        GlobalFrameView, GlobalProfiler, ScopeId,
-    };
-
-    #[test]
-    fn test_short_file_name() {
-        for (before, after) in [
-            ("", ""),
-            ("foo.rs", "foo.rs"),
-            ("foo/bar.rs", "foo/bar.rs"),
-            ("foo/bar/baz.rs", "bar/baz.rs"),
-            ("crates/cratename/src/main.rs", "cratename/src/main.rs"),
-            ("crates/cratename/src/module/lib.rs", "cratename/…/module/lib.rs"),
-            ("workspace/cratename/examples/hello_world.rs", "examples/hello_world.rs"),
-            ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/…/function.rs"),
-            ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/…/runtime.rs"),
-            ]
-            {
-            assert_eq!(short_file_name(before), after);
-        }
-    }
-
-    #[test]
-    fn test_clean_function_name() {
-        assert_eq!(clean_function_name(""), "");
-        assert_eq!(
-            clean_function_name(&format!("foo{}", USELESS_SCOPE_NAME_SUFFIX)),
-            "foo"
-        );
-        assert_eq!(
-            clean_function_name(&format!("foo::bar{}", USELESS_SCOPE_NAME_SUFFIX)),
-            "foo::bar"
-        );
-        assert_eq!(
-            clean_function_name(&format!("foo::bar::baz{}", USELESS_SCOPE_NAME_SUFFIX)),
-            "bar::baz"
-        );
-        assert_eq!(
-            clean_function_name(&format!(
-                "some::GenericThing<_, _>::function_name{}",
-                USELESS_SCOPE_NAME_SUFFIX
-            )),
-            "GenericThing<_, _>::function_name"
-        );
-        assert_eq!(
-            clean_function_name(&format!(
-                "<some::ConcreteType as some::bloody::Trait>::function_name{}",
-                USELESS_SCOPE_NAME_SUFFIX
-            )),
-            "<ConcreteType as Trait>::function_name"
-        );
-    }
+    use crate::{set_scopes_on, GlobalFrameView, GlobalProfiler, ScopeId};
 
     #[test]
     fn profile_macros_test() {

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -31,7 +31,7 @@ pub struct FrameView {
 
 impl Default for FrameView {
     fn default() -> Self {
-        let max_recent = 60 * 60 * 5;
+        let max_recent = 1_000;
         let max_slow = 256;
 
         Self {

--- a/puffin/src/scope_details.rs
+++ b/puffin/src/scope_details.rs
@@ -95,14 +95,18 @@ pub struct ScopeDetails {
     /// Always initialized once registered.
     /// It is `None` when an external library has yet to register this scope.
     pub(crate) scope_id: Option<ScopeId>,
+
     /// A name for a profile scope, a function profile scope does not have a custom provided name.
     pub scope_name: Option<Cow<'static, str>>,
+
     /// The function name of the function in which this scope is contained.
     /// The name might be slightly modified to represent a short descriptive representation.
     pub function_name: Cow<'static, str>,
+
     /// The file path in which this scope is contained.
     /// The path might be slightly modified to represent a short descriptive representation.
     pub file_path: Cow<'static, str>,
+
     /// The exact line number at which this scope is located.
     pub line_nr: u32,
 }

--- a/puffin/src/utils.rs
+++ b/puffin/src/utils.rs
@@ -141,3 +141,52 @@ pub fn short_file_name(path: &str) -> String {
 pub fn type_name_of<T>(_: T) -> &'static str {
     std::any::type_name::<T>()
 }
+
+#[test]
+fn test_short_file_name() {
+    for (before, after) in [
+        ("", ""),
+        ("foo.rs", "foo.rs"),
+        ("foo/bar.rs", "foo/bar.rs"),
+        ("foo/bar/baz.rs", "bar/baz.rs"),
+        ("crates/cratename/src/main.rs", "cratename/src/main.rs"),
+        ("crates/cratename/src/module/lib.rs", "cratename/…/module/lib.rs"),
+        ("workspace/cratename/examples/hello_world.rs", "examples/hello_world.rs"),
+        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/…/function.rs"),
+        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/…/runtime.rs"),
+        ]
+        {
+        assert_eq!(short_file_name(before), after);
+    }
+}
+
+#[test]
+fn test_clean_function_name() {
+    assert_eq!(clean_function_name(""), "");
+    assert_eq!(
+        clean_function_name(&format!("foo{}", USELESS_SCOPE_NAME_SUFFIX)),
+        "foo"
+    );
+    assert_eq!(
+        clean_function_name(&format!("foo::bar{}", USELESS_SCOPE_NAME_SUFFIX)),
+        "foo::bar"
+    );
+    assert_eq!(
+        clean_function_name(&format!("foo::bar::baz{}", USELESS_SCOPE_NAME_SUFFIX)),
+        "bar::baz"
+    );
+    assert_eq!(
+        clean_function_name(&format!(
+            "some::GenericThing<_, _>::function_name{}",
+            USELESS_SCOPE_NAME_SUFFIX
+        )),
+        "GenericThing<_, _>::function_name"
+    );
+    assert_eq!(
+        clean_function_name(&format!(
+            "<some::ConcreteType as some::bloody::Trait>::function_name{}",
+            USELESS_SCOPE_NAME_SUFFIX
+        )),
+        "<ConcreteType as Trait>::function_name"
+    );
+}

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -23,6 +23,7 @@ include = [
 
 [dependencies]
 egui = { version = "0.28.0", default-features = false }
+egui_extras = { version = "0.28.0", default-features = false, features = ["serde"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
 natord = "1.0.9"
 once_cell = "1.7"

--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -41,4 +41,5 @@ web-time = "0.2"
 eframe = { version = "0.28.0", default-features = false, features = [
   "default_fonts",
   "glow",
+  "persistence",
 ] }

--- a/puffin_egui/examples/eframe.rs
+++ b/puffin_egui/examples/eframe.rs
@@ -2,7 +2,9 @@ use eframe::egui;
 
 fn main() -> eframe::Result<()> {
     let mut frame_counter = 0;
-    let mut keep_repainting = false;
+    let mut keep_repainting = true;
+
+    puffin::set_scopes_on(true);
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([320.0, 240.0]),
@@ -43,7 +45,7 @@ fn main() -> eframe::Result<()> {
             })
             .unwrap();
 
-        sleep_ms(14);
+        sleep_ms(9);
         if frame_counter % 49 == 0 {
             puffin::profile_scope!("Spike");
             std::thread::sleep(std::time::Duration::from_millis(20))

--- a/puffin_egui/src/filter.rs
+++ b/puffin_egui/src/filter.rs
@@ -6,9 +6,11 @@ pub struct Filter {
 impl Filter {
     pub fn ui(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
-            ui.label("Scope filter:");
-            ui.text_edit_singleline(&mut self.filter);
+            ui.spacing_mut().item_spacing.x = 4.0;
+
+            ui.add(egui::TextEdit::singleline(&mut self.filter).hint_text("Scope filter"));
             self.filter = self.filter.to_lowercase();
+
             if ui.button("ｘ").clicked() {
                 self.filter.clear();
             }

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -284,6 +284,8 @@ pub fn ui(
     });
 
     Frame::dark_canvas(ui.style()).show(ui, |ui| {
+        ui.visuals_mut().clip_rect_margin = 0.0;
+
         let available_height = ui.max_rect().bottom() - ui.min_rect().bottom();
         ScrollArea::vertical().show(ui, |ui| {
             let mut canvas = ui.available_rect_before_wrap();

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -277,14 +277,15 @@ pub fn ui(
 
         add_space(ui);
 
-        ui.colored_label(ui.visuals().widgets.inactive.text_color(), "❓")
-            .on_hover_text(
+        ui.menu_button("❓", |ui| {
+            ui.label(
                 "Drag to pan.\n\
                         Zoom: Ctrl/cmd + scroll, or drag with secondary mouse button.\n\
                         Click on a scope to zoom to it.\n\
                         Double-click to reset view.\n\
                         Press spacebar to pause/resume.",
             );
+        });
     });
 
     Frame::dark_canvas(ui.style()).show(ui, |ui| {

--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -1,7 +1,7 @@
 use std::vec;
 
 use super::{SelectedFrames, ERROR_COLOR, HOVER_COLOR};
-use crate::{add_space, filter::Filter};
+use crate::filter::Filter;
 use egui::*;
 use indexmap::IndexMap;
 use puffin::*;
@@ -231,9 +231,9 @@ pub fn ui(
     ui.horizontal(|ui| {
         options.scope_name_filter.ui(ui);
 
-        add_space(ui);
-
         ui.menu_button("🔧 Settings", |ui| {
+            ui.set_max_height(500.0);
+
             {
                 let changed = ui
                     .checkbox(&mut options.merge_scopes, "Merge children with same ID")
@@ -260,22 +260,17 @@ pub fn ui(
 
             ui.group(|ui| {
                 ui.strong("Visible Threads");
-                egui::ScrollArea::vertical()
-                    .max_height(150.0)
-                    .id_source("f")
-                    .show(ui, |ui| {
-                        for f in frames.threads.keys() {
-                            let entry = options
-                                .flamegraph_threads
-                                .entry(f.name.clone())
-                                .or_default();
-                            ui.checkbox(&mut entry.flamegraph_show, f.name.clone());
-                        }
-                    });
+                egui::ScrollArea::vertical().id_source("f").show(ui, |ui| {
+                    for f in frames.threads.keys() {
+                        let entry = options
+                            .flamegraph_threads
+                            .entry(f.name.clone())
+                            .or_default();
+                        ui.checkbox(&mut entry.flamegraph_show, f.name.clone());
+                    }
+                });
             });
         });
-
-        add_space(ui);
 
         ui.menu_button("❓", |ui| {
             ui.label(
@@ -788,7 +783,7 @@ fn paint_scope(
                 Id::new("puffin_profiler_tooltip"),
                 |ui| {
                     paint_scope_details(ui, scope.id, scope.record.data, scope_details);
-                    add_space(ui);
+
                     ui.monospace(format!(
                         "duration: {:7.3} ms",
                         to_ms(scope.record.duration_ns)
@@ -910,8 +905,6 @@ fn merge_scope_tooltip(
     };
 
     paint_scope_details(ui, merge.id, &merge.data, scope_details);
-
-    add_space(ui);
 
     if num_frames <= 1 {
         if merge.num_pieces <= 1 {

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -565,7 +565,28 @@ impl ProfilerUi {
 
         egui::Grid::new("frame_grid").num_columns(2).show(ui, |ui| {
             ui.label("");
-            ui.label("Click to select a frame, or drag to select multiple frames.");
+            ui.horizontal(|ui| {
+                ui.label("Click to select a frame, or drag to select multiple frames.");
+
+                ui.menu_button("🔧 Settings", |ui| {
+                    let uniq = &frames.uniq;
+                    let stats = &frames.stats;
+
+                    ui.label(format!(
+                        "{} frames ({} unpacked) using approximately {:.1} MB.",
+                        stats.frames(),
+                        stats.unpacked_frames(),
+                        stats.bytes_of_ram_used() as f64 * 1e-6
+                    ));
+
+                    if let Some(frame_view) = frame_view.as_mut() {
+                        max_frames_ui(ui, frame_view, uniq);
+                        if self.paused.is_none() {
+                            max_num_latest_ui(ui, &mut self.max_num_latest);
+                        }
+                    }
+                });
+            });
             ui.end_row();
 
             ui.label("Recent:");
@@ -624,25 +645,6 @@ impl ProfilerUi {
                 );
             });
         });
-
-        {
-            let uniq = &frames.uniq;
-            let stats = &frames.stats;
-
-            ui.label(format!(
-                "{} frames ({} unpacked) using approximately {:.1} MB.",
-                stats.frames(),
-                stats.unpacked_frames(),
-                stats.bytes_of_ram_used() as f64 * 1e-6
-            ));
-
-            if let Some(frame_view) = frame_view.as_mut() {
-                max_frames_ui(ui, frame_view, uniq);
-                if self.paused.is_none() {
-                    max_num_latest_ui(ui, &mut self.max_num_latest);
-                }
-            }
-        }
 
         hovered_frame
     }
@@ -864,4 +866,8 @@ fn max_num_latest_ui(ui: &mut egui::Ui, max_num_latest: &mut usize) {
         ui.label("Max latest frames to show:");
         ui.add(egui::Slider::new(max_num_latest, 1..=100).logarithmic(true));
     });
+}
+
+fn add_space(ui: &mut Ui) {
+    ui.add_space(8.0); // Looks better than a separator
 }

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -444,13 +444,19 @@ impl ProfilerUi {
             return;
         };
 
+        ui.scope(|ui| {
+            ui.spacing_mut().item_spacing.y = 6.0;
+            self.ui_impl(ui, frame_view);
+        });
+    }
+
+    fn ui_impl(&mut self, ui: &mut egui::Ui, frame_view: &mut MaybeMutRef<'_, FrameView>) {
         let mut hovered_frame = None;
 
         egui::CollapsingHeader::new("Frame history")
             .default_open(false)
             .show(ui, |ui| {
                 hovered_frame = self.show_frames(ui, frame_view);
-                ui.add_space(4.0);
             });
 
         let frames = if let Some(frame) = hovered_frame {
@@ -519,7 +525,7 @@ impl ProfilerUi {
                     }
                 });
             }
-            add_space(ui);
+
             frames_info_ui(ui, &frames);
         });
 
@@ -541,15 +547,11 @@ impl ProfilerUi {
             ui.ctx().request_repaint(); // keep refreshing to see latest data
         }
 
-        add_space(ui);
-
         ui.horizontal(|ui| {
             ui.label("View:");
             ui.selectable_value(&mut self.view, View::Flamegraph, "Flamegraph");
             ui.selectable_value(&mut self.view, View::Stats, "Table");
         });
-
-        add_space(ui);
 
         match self.view {
             View::Flamegraph => flamegraph::ui(
@@ -879,8 +881,4 @@ fn max_num_latest_ui(ui: &mut egui::Ui, max_num_latest: &mut usize) {
         ui.label("Max latest frames to show:");
         ui.add(egui::Slider::new(max_num_latest, 1..=100).logarithmic(true));
     });
-}
-
-fn add_space(ui: &mut Ui) {
-    ui.add_space(8.0); // Looks better than a separator
 }

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -446,7 +446,7 @@ impl ProfilerUi {
 
         let mut hovered_frame = None;
 
-        egui::CollapsingHeader::new("Frames")
+        egui::CollapsingHeader::new("Frame history")
             .default_open(false)
             .show(ui, |ui| {
                 hovered_frame = self.show_frames(ui, frame_view);

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -447,7 +447,7 @@ impl ProfilerUi {
         let mut hovered_frame = None;
 
         egui::CollapsingHeader::new("Frames")
-            .default_open(true)
+            .default_open(false)
             .show(ui, |ui| {
                 hovered_frame = self.show_frames(ui, frame_view);
             });

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -530,8 +530,9 @@ impl ProfilerUi {
         add_space(ui);
 
         ui.horizontal(|ui| {
+            ui.label("View:");
             ui.selectable_value(&mut self.view, View::Flamegraph, "Flamegraph");
-            ui.selectable_value(&mut self.view, View::Stats, "Stats");
+            ui.selectable_value(&mut self.view, View::Stats, "Table");
         });
 
         add_space(ui);

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -450,6 +450,7 @@ impl ProfilerUi {
             .default_open(false)
             .show(ui, |ui| {
                 hovered_frame = self.show_frames(ui, frame_view);
+                ui.add_space(4.0);
             });
 
         let frames = if let Some(frame) = hovered_frame {
@@ -518,7 +519,7 @@ impl ProfilerUi {
                     }
                 });
             }
-            ui.separator();
+            add_space(ui);
             frames_info_ui(ui, &frames);
         });
 
@@ -526,14 +527,14 @@ impl ProfilerUi {
             ui.ctx().request_repaint(); // keep refreshing to see latest data
         }
 
-        ui.separator();
+        add_space(ui);
 
         ui.horizontal(|ui| {
             ui.selectable_value(&mut self.view, View::Flamegraph, "Flamegraph");
             ui.selectable_value(&mut self.view, View::Stats, "Stats");
         });
 
-        ui.separator();
+        add_space(ui);
 
         match self.view {
             View::Flamegraph => flamegraph::ui(

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -1,7 +1,7 @@
 use egui::TextBuffer;
 use puffin::*;
 
-use crate::filter::Filter;
+use crate::{add_space, filter::Filter};
 
 #[derive(Clone, Debug, Default)]
 pub struct Options {
@@ -41,11 +41,11 @@ pub fn ui(
         threads.len()
     ));
 
-    ui.separator();
+    add_space(ui);
 
     options.filter.ui(ui);
 
-    ui.separator();
+    add_space(ui);
 
     let mut scopes: Vec<_> = stats
         .scopes

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -56,21 +56,44 @@ pub fn ui(
     scopes.sort_by_key(|(_key, scope_stats)| scope_stats.bytes);
     scopes.reverse();
 
-    egui::ScrollArea::vertical().show(ui, |ui| {
-        egui::Grid::new("table")
-            .spacing([32.0, ui.spacing().item_spacing.y])
-            .show(ui, |ui| {
-                ui.heading("Thread");
-                ui.heading("Location");
-                ui.heading("Function Name");
-                ui.heading("Scope Name");
-                ui.heading("Count");
-                ui.heading("Size");
-                ui.heading("Total self time");
-                ui.heading("Mean self time");
-                ui.heading("Max self time");
-                ui.end_row();
+    egui::ScrollArea::horizontal().show(ui, |ui| {
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
 
+        egui_extras::TableBuilder::new(ui)
+            .columns(
+                egui_extras::Column::auto_with_initial_suggestion(200.0).resizable(true),
+                9,
+            )
+            .header(20.0, |mut header| {
+                header.col(|ui| {
+                    ui.heading("Thread");
+                });
+                header.col(|ui| {
+                    ui.heading("Location");
+                });
+                header.col(|ui| {
+                    ui.heading("Function Name");
+                });
+                header.col(|ui| {
+                    ui.heading("Scope Name");
+                });
+                header.col(|ui| {
+                    ui.heading("Count");
+                });
+                header.col(|ui| {
+                    ui.heading("Size");
+                });
+                header.col(|ui| {
+                    ui.heading("Total self time");
+                });
+                header.col(|ui| {
+                    ui.heading("Mean self time");
+                });
+                header.col(|ui| {
+                    ui.heading("Max self time");
+                });
+            })
+            .body(|mut body| {
                 for (key, stats) in &scopes {
                     let Some(scope_details) = scope_infos.fetch_by_id(&key.id) else {
                         continue;
@@ -80,24 +103,44 @@ pub fn ui(
                         return;
                     }
 
-                    ui.label(&key.thread_name);
-                    ui.label(scope_details.location());
-                    ui.label(scope_details.function_name.as_str());
+                    body.row(14.0, |mut row| {
+                        row.col(|ui| {
+                            ui.label(&key.thread_name);
+                        });
+                        row.col(|ui| {
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+                            ui.label(scope_details.location());
+                        });
+                        row.col(|ui| {
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+                            ui.label(scope_details.function_name.as_str());
+                        });
 
-                    if let Some(name) = &scope_details.scope_name {
-                        ui.label(name.as_ref());
-                    } else {
-                        ui.label("-");
-                    }
-                    ui.monospace(format!("{:>5}", stats.count));
-                    ui.monospace(format!("{:>6.1} kB", stats.bytes as f32 * 1e-3));
-                    ui.monospace(format!("{:>8.1} µs", stats.total_self_ns as f32 * 1e-3));
-                    ui.monospace(format!(
-                        "{:>8.1} µs",
-                        stats.total_self_ns as f32 * 1e-3 / (stats.count as f32)
-                    ));
-                    ui.monospace(format!("{:>8.1} µs", stats.max_ns as f32 * 1e-3));
-                    ui.end_row();
+                        row.col(|ui| {
+                            if let Some(name) = &scope_details.scope_name {
+                                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+                                ui.label(name.as_ref());
+                            }
+                        });
+                        row.col(|ui| {
+                            ui.monospace(format!("{:>5}", stats.count));
+                        });
+                        row.col(|ui| {
+                            ui.monospace(format!("{:>6.1} kB", stats.bytes as f32 * 1e-3));
+                        });
+                        row.col(|ui| {
+                            ui.monospace(format!("{:>8.1} µs", stats.total_self_ns as f32 * 1e-3));
+                        });
+                        row.col(|ui| {
+                            ui.monospace(format!(
+                                "{:>8.1} µs",
+                                stats.total_self_ns as f32 * 1e-3 / (stats.count as f32)
+                            ));
+                        });
+                        row.col(|ui| {
+                            ui.monospace(format!("{:>8.1} µs", stats.max_ns as f32 * 1e-3));
+                        });
+                    });
                 }
             });
     });

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -99,8 +99,16 @@ pub fn ui(
                         continue;
                     };
 
-                    if !options.filter.include(scope_details.name()) {
-                        return;
+                    if !options.filter.is_empty() {
+                        let mut matches = options.filter.include(&scope_details.function_name);
+
+                        if let Some(scope_name) = &scope_details.scope_name {
+                            matches |= options.filter.include(scope_name);
+                        }
+
+                        if !matches {
+                            continue;
+                        }
                     }
 
                     body.row(14.0, |mut row| {

--- a/puffin_egui/src/stats.rs
+++ b/puffin_egui/src/stats.rs
@@ -1,7 +1,7 @@
 use egui::TextBuffer;
 use puffin::*;
 
-use crate::{add_space, filter::Filter};
+use crate::filter::Filter;
 
 #[derive(Clone, Debug, Default)]
 pub struct Options {
@@ -31,22 +31,18 @@ pub fn ui(
         total_ns += scope.total_self_ns;
     }
 
-    ui.label("This view can be used to find functions that are called a lot.");
-    ui.label("The overhead of a profile scope is around ~50ns, so remove profile scopes from fast functions that are called often.");
+    ui.label("This view can be used to find functions that are called a lot.\n\
+              The overhead of a profile scope is around ~50ns, so remove profile scopes from fast functions that are called often.");
 
     ui.label(format!(
-        "Current frame: {} unique scopes, using a total of {:.1} kB, covering {:.1} ms over {} thread(s)",
+        "Currently viewing {} unique scopes, using a total of {:.1} kB, covering {:.1} ms over {} thread(s)",
         stats.scopes.len(),
         total_bytes as f32 * 1e-3,
         total_ns as f32 * 1e-6,
         threads.len()
     ));
 
-    add_space(ui);
-
     options.filter.ui(ui);
-
-    add_space(ui);
 
     let mut scopes: Vec<_> = stats
         .scopes

--- a/puffin_viewer/src/lib.rs
+++ b/puffin_viewer/src/lib.rs
@@ -155,7 +155,7 @@ impl PuffinViewer {
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
                 egui::widgets::global_dark_light_mode_switch(ui);
-                ui.separator();
+                ui.add_space(4.0);
 
                 ui.menu_button("File", |ui| {
                     if ui.button("Open…").clicked() {
@@ -242,7 +242,7 @@ impl eframe::App for PuffinViewer {
         egui::TopBottomPanel::bottom("info_bar").show(ctx, |ui| {
             if let Some(error) = &self.error {
                 ui.colored_label(egui::Color32::RED, error);
-                ui.separator();
+                ui.add_space(4.0);
             }
 
             if self.profile_self {

--- a/puffin_viewer/src/lib.rs
+++ b/puffin_viewer/src/lib.rs
@@ -155,7 +155,6 @@ impl PuffinViewer {
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
                 egui::widgets::global_dark_light_mode_switch(ui);
-                ui.add_space(4.0);
 
                 ui.menu_button("File", |ui| {
                     if ui.button("Open…").clicked() {

--- a/puffin_viewer/src/main.rs
+++ b/puffin_viewer/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), eframe::Error> {
         viewport: eframe::egui::ViewportBuilder::default()
             .with_app_id("puffin_viewer")
             .with_drag_and_drop(true)
+            .with_inner_size([1400.0, 1000.0])
             .with_icon(icon),
         ..Default::default()
     };


### PR DESCRIPTION
It's high time it got a face lift.

This reduces the clutter, hiding settings in menus.

It also renamed the "Stats" view to "Table", and makes it a bit nicer.

### Previous default view (BEFORE!)
<img width="912" alt="Screenshot 2024-07-31 at 14 28 39" src="https://github.com/user-attachments/assets/d2640157-3727-4b89-bff6-fda70eb539da">


### New default view
<img width="1512" alt="Screenshot 2024-07-31 at 14 25 01" src="https://github.com/user-attachments/assets/ff62214a-eb40-457f-aa15-27ae904230fc">

### Flamegraph with expanded `Frame history` and setting
<img width="1171" alt="Screenshot 2024-07-31 at 14 25 26" src="https://github.com/user-attachments/assets/7fcc9149-009d-4d38-b5e2-d9ccbaa265f3">

### Table view
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/6f8402b6-a0bd-49fe-a872-52fce7e4de9b">
