### PR TITLE
Remove `::{{closure}}` in more cases from function names

### DIFF
--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -178,9 +178,12 @@ macro_rules! current_function_name {
     }};
 }
 
-/// Automatically name the profiling scope based on function name.
+/// Automatically name the profiling scope based on the function name.
 ///
 /// Names should be descriptive, ASCII and without spaces.
+/// 
+/// [`profile_function`] should only be used for the outermost scope of a function
+/// and not for lambdas. For other use-cases please use [`profile_scope`]
 ///
 /// Example:
 /// ```

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -181,7 +181,7 @@ macro_rules! current_function_name {
 /// Automatically name the profiling scope based on the function name.
 ///
 /// Names should be descriptive, ASCII and without spaces.
-/// 
+///
 /// [`profile_function`] should only be used for the outermost scope of a function
 /// and not for lambdas. For other use-cases please use [`profile_scope`]
 ///

--- a/puffin/src/utils.rs
+++ b/puffin/src/utils.rs
@@ -11,7 +11,7 @@ pub fn clean_function_name(name: &str) -> String {
         // Probably the user registered a user scope name.
         return name.to_owned();
     };
-    // Remove any additional trailing suffixes 
+    // Remove any additional trailing suffixes
     shorten_rust_function_name(name.trim_end_matches(USELESS_CLOSURE_SUFFIX))
 }
 

--- a/puffin/src/utils.rs
+++ b/puffin/src/utils.rs
@@ -1,7 +1,10 @@
 // The macro defines 'f()' at the place where macro is called.
-// This code is located at the place of call and two closures deep.
+// This code is typically located at the place of call and two closures deep.
 // Strip away this useless suffix.
-pub(crate) const USELESS_SCOPE_NAME_SUFFIX: &str = "::{{closure}}::{{closure}}::f";
+pub(crate) const USELESS_SCOPE_NAME_SUFFIX: &str = "::f";
+// By having this seperated out from the suffix we can remove all clouser names
+// regardless of depth.
+pub(crate) const USELESS_CLOSURE_SUFFIX: &str = "::{{closure}}";
 
 #[doc(hidden)]
 #[inline(never)]
@@ -10,7 +13,8 @@ pub fn clean_function_name(name: &str) -> String {
         // Probably the user registered a user scope name.
         return name.to_owned();
     };
-    shorten_rust_function_name(name)
+    // Remove any additional trailing suffixes 
+    shorten_rust_function_name(name.trim_end_matches(USELESS_CLOSURE_SUFFIX))
 }
 
 /// Shorten a rust function name by removing the leading parts of module paths.

--- a/puffin/src/utils.rs
+++ b/puffin/src/utils.rs
@@ -2,8 +2,6 @@
 // This code is typically located at the place of call and two closures deep.
 // Strip away this useless suffix.
 pub(crate) const USELESS_SCOPE_NAME_SUFFIX: &str = "::f";
-// By having this seperated out from the suffix we can remove all clouser names
-// regardless of depth.
 pub(crate) const USELESS_CLOSURE_SUFFIX: &str = "::{{closure}}";
 
 #[doc(hidden)]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This removes all `::{{closure}}` from the suffix of a function name when cleaning the name. Previously this was limited to 2. 

This is noticeable with the changes made in #225 where the `main function` being labeled as `main::{{closure}}`

### Before
![image](https://github.com/user-attachments/assets/a484973e-088e-48cc-bef8-589db8b9bfd4)

### After 
![Screenshot 2024-08-05 131903](https://github.com/user-attachments/assets/84830f94-9d2b-4249-9295-e7d4896ad958)

