### PR TITLE
Expose UI options

### DIFF
--- a/puffin_egui/src/flamegraph.rs
+++ b/puffin_egui/src/flamegraph.rs
@@ -127,8 +127,9 @@ pub struct Options {
     /// Interval of vertical timeline indicators.
     grid_spacing_micros: f64,
 
+    /// Filter to highlight specific functions or scopes matching the filter.
     #[cfg_attr(feature = "serde", serde(skip))]
-    scope_name_filter: Filter,
+    pub scope_name_filter: Filter,
 
     /// Set when user clicks a scope.
     /// First part is `now()`, second is range.

--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -84,7 +84,13 @@ pub fn profiler_window(ctx: &egui::Context) -> bool {
     open
 }
 
-static PROFILE_UI: once_cell::sync::Lazy<parking_lot::Mutex<GlobalProfilerUi>> =
+/// Profiler ui used internally.
+///
+/// Use this if you need to read or change options arbitrarily.
+///
+/// Be mindful that this might result in unexpected changes for the user,
+/// as a user expect changes to occur when interacting with the ui.
+pub static PROFILE_UI: once_cell::sync::Lazy<parking_lot::Mutex<GlobalProfilerUi>> =
     once_cell::sync::Lazy::new(Default::default);
 
 /// Show the profiler.


### PR DESCRIPTION
Profiling a binary can be difficult when a lot of dependencies include profiling information, I couldn´t find a good way to filter irrelevant profiling information, so I settled for providing a default highlight filter.

I need a few data exposed from puffin to do that though, so this PR does that.



- More background context: https://github.com/dimforge/rapier/pull/743#issuecomment-2455101120