### PR TITLE
Fix cargo-vet CI step by use stable rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Ensure that the tool cache is populated with the cargo-vet binary
         # build from source, as are not published binaries yet :(
         # tracked in https://github.com/mozilla/cargo-vet/issues/484
-        run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+        run: cargo +stable install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
       - name: Invoke cargo-vet
         run: |
           cargo vet --locked


### PR DESCRIPTION
It's not necessary to use the toolchain specified for puffin. And `cargo-vet` failed to build with 1.76 toolchain.

### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Setup `cargo-vet` CI step to build cargo-vet with `stable` Rust toolchain.

### Related Issues

Currently `cargo-vet` v0.9.1 failed to build with Rust toolchain v1.73.0
