### PR TITLE
enable features wayland and x11 for eframe dev-dependency of puffin_egui

### DIFF
--- a/puffin_egui/Cargo.toml
+++ b/puffin_egui/Cargo.toml
@@ -46,4 +46,6 @@ eframe = { version = "0.31.0", default-features = false, features = [
   "default_fonts",
   "glow",
   "persistence",
+  "wayland",
+  "x11",
 ] }


### PR DESCRIPTION
this should fix cargo test of puffin_egui package

### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

enable features wayland and x11 for eframe dev-dependency of puffin_egui

### Related Issues

CI Workflow Test failed :
[Test](https://github.com/EmbarkStudios/puffin/actions/runs/16800793169/job/47581504774)
