### PR TITLE
puffin_http: keep scopes in server if no client

### DIFF
--- a/puffin_http/src/server.rs
+++ b/puffin_http/src/server.rs
@@ -375,14 +375,16 @@ impl PuffinServerImpl {
     }
 
     pub fn send(&mut self, frame: &puffin::FrameData) -> anyhow::Result<()> {
-        if self.clients.is_empty() {
-            return Ok(());
-        }
         puffin::profile_function!();
 
         // Keep scope_collection up-to-date
         for new_scope in &frame.scope_delta {
             self.scope_collection.insert(new_scope.clone());
+        }
+
+        // Nothing to send if no clients => Early return.
+        if self.clients.is_empty() {
+            return Ok(());
         }
 
         let mut packet = vec![];


### PR DESCRIPTION
As only the new scopes will be present in the following frames, it's necessary to keep scopes from the start to send it to clients.

### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When there is no client connected, keep scope_collection up-to-date to send it on connection.
As only the new scopes will be present in the following frames, it's necessary to keep scopes from the start to send it to clients.

### Related Issues

possible fix for issue #200
