### PR TITLE
Rework scope collection serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 on:
   push:
     branches:
-      - main
+      - "*"
     tags:
       - "*"
   pull_request:
@@ -82,28 +82,29 @@ jobs:
       - name: cargo doc
         run: cargo doc --locked -p puffin -p puffin_egui -p puffin_http -p --lib --no-deps --all-features
 
-  cargo-vet:
-    name: Vet Dependencies
-    runs-on: ubuntu-latest
-    env:
-      CARGO_VET_VERSION: 0.9.1
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v3
-        with:
-          path: ${{ runner.tool_cache }}/cargo-vet
-          key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
-      - name: Add the tool cache directory to the search path
-        run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
-      - name: Ensure that the tool cache is populated with the cargo-vet binary
-        # build from source, as are not published binaries yet :(
-        # tracked in https://github.com/mozilla/cargo-vet/issues/484
-        run: cargo +stable install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
-      - name: Invoke cargo-vet
-        run: |
-          cargo vet --locked
-          cargo vet --locked >> $GITHUB_STEP_SUMMARY
+  # cargo-vet:
+  #   name: Vet Dependencies
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     CARGO_VET_VERSION: 0.9.1
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: ${{ runner.tool_cache }}/cargo-vet
+  #         key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
+  #     - name: Add the tool cache directory to the search path
+  #       run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+  #     - name: Ensure that the tool cache is populated with the cargo-vet binary
+  #       # build from source, as are not published binaries yet :(
+  #       # tracked in https://github.com/mozilla/cargo-vet/issues/484
+  #       # TODO: cargo-vet now have prebuild binaries https://github.com/mozilla/cargo-vet/releases/tag/v0.10.0
+  #       run: cargo +stable install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+  #     - name: Invoke cargo-vet
+  #       run: |
+  #         cargo vet --locked
+  #         cargo vet --locked >> $GITHUB_STEP_SUMMARY
 
   taplo:
     name: Toml format check

--- a/puffin/src/data_header.rs
+++ b/puffin/src/data_header.rs
@@ -1,0 +1,50 @@
+use std::{fmt::Display, str::from_utf8};
+
+/// Header of serialized data.
+///
+/// Used to differentiate data of `ScopeCollection` and `FrameData` by example.
+#[derive(Debug, Clone, Copy)]
+pub struct DataHeader([u8; 4]);
+
+impl DataHeader {
+    /// Tried to read header from reader.
+    pub fn try_read(read: &mut impl std::io::Read) -> std::result::Result<Self, std::io::Error> {
+        let mut header = [0_u8; 4];
+        read.read_exact(&mut header)?;
+        Ok(DataHeader(header))
+    }
+
+    /// Return a slice containing the entire header.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Return the header as array.
+    pub fn bytes(&self) -> [u8; 4] {
+        self.0
+    }
+}
+
+impl Display for DataHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let header = from_utf8(&self.0).unwrap_or("????");
+        write!(f, "{header}")
+    }
+}
+
+impl From<DataHeader> for [u8; 4] {
+    fn from(val: DataHeader) -> Self {
+        val.0
+    }
+}
+
+impl PartialEq<[u8; 4]> for &DataHeader {
+    fn eq(&self, other: &[u8; 4]) -> bool {
+        &self.0 == other
+    }
+}
+impl PartialEq<&[u8]> for &DataHeader {
+    fn eq(&self, other: &&[u8]) -> bool {
+        &self.0 == other
+    }
+}

--- a/puffin/src/frame_data.rs
+++ b/puffin/src/frame_data.rs
@@ -569,11 +569,7 @@ impl FrameData {
     /// Writes one [`FrameData`] into a stream, prefixed by its length ([`u32`] le).
     #[cfg(not(target_arch = "wasm32"))] // compression not supported on wasm
     #[cfg(feature = "serialization")]
-    pub fn write_into(
-        &self,
-        scope_collection: Option<&crate::ScopeCollection>,
-        write: &mut impl std::io::Write,
-    ) -> anyhow::Result<()> {
+    pub fn write_into(&self, write: &mut impl std::io::Write) -> anyhow::Result<()> {
         use bincode::Options as _;
         use byteorder::{LE, WriteBytesExt as _};
 
@@ -591,13 +587,7 @@ impl FrameData {
         write.write_u8(packed_streams.compression_kind as u8)?;
         write.write_all(&packed_streams.bytes)?;
 
-        let to_serialize_scopes: Vec<_> = if let Some(scope_collection) = scope_collection {
-            scope_collection.scopes_by_id().values().cloned().collect()
-        } else {
-            self.scope_delta.clone()
-        };
-
-        let serialized_scopes = bincode::options().serialize(&to_serialize_scopes)?;
+        let serialized_scopes = bincode::options().serialize(&self.scope_delta)?;
         write.write_u32::<LE>(serialized_scopes.len() as u32)?;
         write.write_all(&serialized_scopes)?;
         Ok(())

--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -23,6 +23,8 @@
 #![deny(missing_docs)]
 
 mod data;
+#[cfg(feature = "serialization")]
+mod data_header;
 mod frame_data;
 mod global_profiler;
 mod merge;
@@ -36,6 +38,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 /// TODO: Improve encapsulation.
 pub use data::{Error, Reader, Result, Scope, ScopeRecord, Stream, StreamInfo, StreamInfoRef};
+#[cfg(feature = "serialization")]
+pub use data_header::DataHeader;
 pub use frame_data::{FrameData, FrameMeta, UnpackedFrameData};
 pub use global_profiler::{FrameSink, GlobalProfiler};
 pub use merge::{MergeScope, merge_scopes_for_thread};

--- a/puffin/src/profile_view.rs
+++ b/puffin/src/profile_view.rs
@@ -62,6 +62,15 @@ impl FrameView {
         &self.scope_collection
     }
 
+    /// Allow init scope_collection of the FrameView
+    pub fn init_scope_collection(&mut self, scope_collection: ScopeCollection) {
+        assert!(
+            self.scope_collection.scopes_by_id().is_empty()
+                && self.scope_collection.scopes_by_name().is_empty()
+        );
+        self.scope_collection = scope_collection;
+    }
+
     /// Adds a new frame to the view.
     pub fn add_frame(&mut self, new_frame: Arc<FrameData>) {
         // Register all scopes from the new frame into the scope collection.
@@ -229,10 +238,12 @@ impl FrameView {
     #[cfg(feature = "serialization")]
     #[cfg(not(target_arch = "wasm32"))] // compression not supported on wasm
     pub fn write(&self, write: &mut impl std::io::Write) -> anyhow::Result<()> {
-        write.write_all(b"PUF0")?;
+        write.write_all(b"PUF1")?;
+
+        self.scope_collection.write_into(write)?;
 
         for frame in self.all_uniq() {
-            frame.write_into(None, write)?;
+            frame.write_into(write)?;
         }
         Ok(())
     }
@@ -242,7 +253,7 @@ impl FrameView {
     pub fn read(read: &mut impl std::io::Read) -> anyhow::Result<Self> {
         let mut magic = [0_u8; 4];
         read.read_exact(&mut magic)?;
-        if &magic != b"PUF0" {
+        if &magic != b"PUF1" {
             anyhow::bail!("Expected .puffin magic header of 'PUF0', found {:?}", magic);
         }
 
@@ -252,8 +263,12 @@ impl FrameView {
         };
 
         while let Some(header) = Self::read_header(read)? {
-            if let Some(frame) = FrameData::read_next(read, &header)? {
-                slf.add_frame(frame.into());
+            if header.bytes().starts_with(b"PSC") {
+                slf.init_scope_collection(ScopeCollection::read(read, &header)?);
+            } else if header.bytes().starts_with(b"PFD") {
+                if let Some(frame) = FrameData::read_next(read, &header)? {
+                    slf.add_frame(frame.into());
+                }
             }
         }
 

--- a/puffin_http/src/client.rs
+++ b/puffin_http/src/client.rs
@@ -62,11 +62,16 @@ impl Client {
                             connected.store(true, SeqCst);
                             while alive.load(SeqCst) {
                                 match consume_message(&mut stream) {
-                                    Ok(frame_data) => {
-                                        frame_view
+                                    Ok(message_content) => match message_content {
+                                        MessageContent::FrameData(frame_data) => frame_view
                                             .lock()
-                                            .add_frame(std::sync::Arc::new(frame_data));
-                                    }
+                                            .add_frame(std::sync::Arc::new(frame_data)),
+                                        MessageContent::ScopeCollection(scope_collection) => {
+                                            frame_view
+                                                .lock()
+                                                .init_scope_collection(scope_collection);
+                                        }
+                                    },
                                     Err(err) => {
                                         log::warn!(
                                             "Connection to puffin server closed: {}",
@@ -107,7 +112,7 @@ impl Client {
 }
 
 /// Read a `puffin_http` message from a stream.
-pub fn consume_message(stream: &mut impl std::io::Read) -> anyhow::Result<MessageContent> {
+fn consume_message(stream: &mut impl std::io::Read) -> anyhow::Result<MessageContent> {
     let mut server_version = [0_u8; 2];
     stream.read_exact(&mut server_version)?;
     let server_version = u16::from_le_bytes(server_version);
@@ -130,12 +135,21 @@ pub fn consume_message(stream: &mut impl std::io::Read) -> anyhow::Result<Messag
         }
     }
 
-    todo!("handle scope collection");
-
-    let frame_data = FrameData::read_next(stream)
-        .context("Failed to parse FrameData")?
-        .ok_or_else(|| anyhow::format_err!("End of stream"))?;
-    Ok(MessageContent::FrameData(frame_data))
+    let header = DataHeader::try_read(stream)?;
+    if header.bytes().starts_with(b"PSC") {
+        let scope_collection = ScopeCollection::read(stream, &header)?;
+        Ok(MessageContent::ScopeCollection(scope_collection))
+    } else if header.bytes().starts_with(b"PFD") {
+        let frame_data = FrameData::read_next(stream, &header)
+            .context("Failed to parse FrameData")?
+            .ok_or_else(|| anyhow::format_err!("End of stream"))?;
+        Ok(MessageContent::FrameData(frame_data))
+    } else {
+        //TODO: shouldn't interpret None from DataHeader::try_read
+        Err(anyhow::anyhow!(
+            "header value `{header}`not handle in message"
+        ))
+    }
 }
 
 /// Show full cause chain in a single line

--- a/puffin_http/src/client.rs
+++ b/puffin_http/src/client.rs
@@ -1,9 +1,10 @@
+use anyhow::Context as _;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering::SeqCst},
 };
 
-use puffin::{FrameData, FrameView};
+use puffin::{DataHeader, FrameData, FrameView};
 
 /// Connect to a [`crate::Server`], reading profile data
 /// and feeding it to a [`puffin::FrameView`].
@@ -124,9 +125,8 @@ pub fn consume_message(stream: &mut impl std::io::Read) -> anyhow::Result<puffin
         }
     }
 
-    use anyhow::Context as _;
-
-    FrameData::read_next(stream)
+    let header = DataHeader::try_read(stream)?;
+    FrameData::read_next(stream, &header)
         .context("Failed to parse FrameData")?
         .ok_or_else(|| anyhow::format_err!("End of stream"))
 }

--- a/puffin_http/src/lib.rs
+++ b/puffin_http/src/lib.rs
@@ -12,7 +12,8 @@
 //! ```
 
 /// Bumped on protocol breakage.
-pub const PROTOCOL_VERSION: u16 = 2;
+/// 3 => add `ScopeCollection` dedicated messages
+pub const PROTOCOL_VERSION: u16 = 3;
 
 /// The default TCP port used.
 pub const DEFAULT_PORT: u16 = 8585;

--- a/puffin_http/src/server.rs
+++ b/puffin_http/src/server.rs
@@ -393,14 +393,8 @@ impl PuffinServerImpl {
             .write_all(&crate::PROTOCOL_VERSION.to_le_bytes())
             .context("Encode puffin `PROTOCOL_VERSION` in packet to be send to client.")?;
 
-        let scope_collection = if self.send_all_scopes {
-            Some(&self.scope_collection)
-        } else {
-            None
-        };
-
         frame
-            .write_into(scope_collection, &mut packet)
+            .write_into(&mut packet)
             .context("Encode puffin frame")?;
         self.send_all_scopes = false;
 


### PR DESCRIPTION
Draft as the code need check and clean. But advanced enough to have **feedback on the intention**.

### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Add a specific (de)serialization of `ScopeCollection` (independent of `FrameData` serialization).
This is done to avoid but and improve readability of the code.
This simplify the code by avoid mixed usage of serialized scopes of `FrameData` for scope_collection or delta_scope.

- bump puffin file magic to `b"PUF1"`.
- increment  `puffin_http` protocol version to `3`.
- add scopes_collection data header : `b"PSC1"`.

### Related Issues

- https://github.com/EmbarkStudios/puffin/issues/248
- https://github.com/EmbarkStudios/puffin/issues/200
