### PR TITLE
Inline `are_scopes_on()` (80% perf improvement)

### DIFF
--- a/puffin/src/lib.rs
+++ b/puffin/src/lib.rs
@@ -57,6 +57,7 @@ pub fn set_scopes_on(on: bool) {
 /// This is [`false`] by default.
 ///
 /// Turn on with [`set_scopes_on`].
+#[inline]
 pub fn are_scopes_on() -> bool {
     MACROS_ON.load(Ordering::Relaxed)
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`are_scopes_on()` is just an atomic load, which is usually implemented as a single instruction. Function call adds a comparable overhead here.

If I understand this correctly, non-generic functions that are not explicitly marked as inline are never inlined automatically across multiple crates unless LTO is enabled. And LTO is disabled in the default "release" profile.

This simple change consistently improves performance of all "profile_*_off" benchmarks.

Here is the benchmarking result (on AMD 5950X):

	profile_function        time:   [51.456 ns 51.504 ns 51.592 ns]
							change: [-0.5310% -0.3454% -0.1507%] (p = 0.00 < 0.05)
							Change within noise threshold.
	Found 8 outliers among 100 measurements (8.00%)
	  1 (1.00%) low severe
	  2 (2.00%) high mild
	  5 (5.00%) high severe

	profile_function_data   time:   [51.236 ns 51.248 ns 51.261 ns]
							change: [-1.2383% -1.0397% -0.8188%] (p = 0.00 < 0.05)
							Change within noise threshold.
	Found 5 outliers among 100 measurements (5.00%)
	  1 (1.00%) low severe
	  1 (1.00%) low mild
	  3 (3.00%) high severe

	profile_scope           time:   [51.467 ns 51.557 ns 51.684 ns]
							change: [-0.5708% -0.3103% +0.0475%] (p = 0.04 < 0.05)
							Change within noise threshold.
	Found 13 outliers among 100 measurements (13.00%)
	  4 (4.00%) low severe
	  1 (1.00%) low mild
	  2 (2.00%) high mild
	  6 (6.00%) high severe

	profile_scope_data      time:   [51.274 ns 51.290 ns 51.308 ns]
							change: [-2.6908% -1.9705% -1.4753%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 11 outliers among 100 measurements (11.00%)
	  1 (1.00%) low severe
	  1 (1.00%) low mild
	  6 (6.00%) high mild
	  3 (3.00%) high severe

	flush_frames            time:   [660.64 ns 661.83 ns 663.19 ns]
							change: [-2.1833% -1.8016% -1.4236%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 3 outliers among 100 measurements (3.00%)
	  1 (1.00%) high mild
	  2 (2.00%) high severe

	profile_function_off    time:   [210.88 ps 210.97 ps 211.10 ps]
							change: [-80.026% -79.583% -78.978%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 8 outliers among 100 measurements (8.00%)
	  1 (1.00%) high mild
	  7 (7.00%) high severe

	profile_function_data_off
							time:   [210.12 ps 210.45 ps 210.94 ps]
							change: [-80.269% -80.242% -80.203%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 7 outliers among 100 measurements (7.00%)
	  3 (3.00%) high mild
	  4 (4.00%) high severe

	profile_scope_off       time:   [210.34 ps 210.50 ps 210.70 ps]
							change: [-83.426% -83.386% -83.339%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 6 outliers among 100 measurements (6.00%)
	  6 (6.00%) high severe

	profile_scope_data_off  time:   [210.11 ps 210.47 ps 211.05 ps]
							change: [-80.162% -80.133% -80.106%] (p = 0.00 < 0.05)
							Performance has improved.
	Found 5 outliers among 100 measurements (5.00%)
	  3 (3.00%) high mild
	  2 (2.00%) high severe

### Related Issues

N/A