### PR TITLE
Update MSRV to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["puffin", "puffin_egui", "puffin_http", "puffin_viewer"]
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.86"
+rust-version = "1.87"
 
 
 [profile.dev.package."*"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.86.0"
+msrv = "1.87.0"
 
 avoid-breaking-exported-api = false
 allow-expect-in-tests = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.86" # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
+channel = "1.87" # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Required because I want to run `cargo semver-checks` before the next release, and it requires 1.87