### PR TITLE
Prevent deadlock when calling `new_frame` from another thread 

### DIFF
--- a/puffin_egui/src/lib.rs
+++ b/puffin_egui/src/lib.rs
@@ -91,6 +91,7 @@ static PROFILE_UI: once_cell::sync::Lazy<parking_lot::Mutex<GlobalProfilerUi>> =
 ///
 /// Call this from within an [`egui::Window`], or use [`profiler_window`] instead.
 pub fn profiler_ui(ui: &mut egui::Ui) {
+    puffin::profile_function!();
     let mut profile_ui = PROFILE_UI.lock();
 
     profile_ui.ui(ui);


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Add a profiling scope to `profiler_ui`. This mitigates a deadlock when calling `new_frame` (i.e. `profiling::finish_frame!()`) from a different thread than `profiler_ui`. Prevent #197 from occuring.

### Related Issues
 - #197